### PR TITLE
Add bootstrap dependencies for nav tabs in docs

### DIFF
--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -19,7 +19,9 @@
     <title>Crossplane Docs</title>
 
     {% include favicon.html %}
-
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css">
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js"></script>
     <link rel="stylesheet" href="{{ "/css/main.css" | relative_url }}" />
     <link rel="stylesheet" href="{{ "/css/docs.css" | relative_url }}" />
   </head>


### PR DESCRIPTION
This adds some bootstrap dependencies that are needed for nav tabs in markdown docs. See screenshots below and https://github.com/crossplane/crossplane/pull/1514 for more info. I am sure I am committing all sorts of web dev crimes here, but it is a suitable solution for now and only affects the docs layout, not the landing page or others.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

![tabs-1](https://user-images.githubusercontent.com/31777345/82151963-f7fc3600-9823-11ea-8551-baaebb5448bf.png)
![tabs-2](https://user-images.githubusercontent.com/31777345/82151965-f894cc80-9823-11ea-8d33-386595cce8a9.png)
