### PR TITLE
add incremental local docs option to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,16 @@ run_docs_local: local_docs_dir _data/versions.json
 		jekyll serve --livereload --livereload-port 4001
 	rm -d $(LOCAL_DOCS_DIR)
 
+run_docs_local_incremental: local_docs_dir _data/versions.json
+	docker run --rm -it \
+		-p 4000:4000 -p 4001:4001 \
+		-v="$(PWD)/vendor/bundle:/usr/local/bundle" \
+		-v "$(PWD):/srv/jekyll" \
+		-v "$(GOPATH)/src/github.com/crossplane/crossplane/docs:/srv/jekyll/$(LOCAL_DOCS_DIR)" \
+		jekyll/jekyll -- \
+		jekyll serve --incremental --livereload --livereload-port 4001
+	rm -d $(LOCAL_DOCS_DIR)
+
 # Build (output is in _site)
 build: _data/versions.json
 	docker run --rm -it \

--- a/README.md
+++ b/README.md
@@ -23,4 +23,11 @@ brew install npm
 make run_docs_local
 ```
 
+To run with --incremental for faster editing:
+```
+make run_docs_local_incremental
+```
+Note: `--incremental` is experimental, and sometimes gets stuck:
+https://jekyllrb.com/docs/configuration/incremental-regeneration/
+
 Open http://localhost:4000 in your browser.


### PR DESCRIPTION
run jekyll with  `--incremental` for faster editing using `make run_docs_local_incremental`
