### PR TITLE
Fix Edit on Github link for all docs pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -29,7 +29,7 @@ defaults:
       path: "docs"
     values:
       layout: "docs"
-      github: "https://github.com/crossplane/crossplane/blob/master/docs/"
+      github: "https://github.com/crossplane/crossplane/tree"
 
 sass:
   sass_dir: ./_scss

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -2,9 +2,11 @@
 
 {% assign url = page.url | split: '/' %}
 {% assign currentVersion = url[2] %}
+{% assign currentVersionBranch = currentVersion | replace: 'v', 'release-' %}
 {% assign currentVersionPath = '/docs/' | append: currentVersion | append: '/' %}
 {% assign latestVersion = site.data.versions[0].version %}
 {% assign filepath = page.url | replace: currentVersionPath %}
+{% assign repopath = 'docs/' | append: filepath | remove: '.html' | append: '.md' %}
 
 {% include mkhash.inc title = 'Welcome' url = currentVersionPath %}
 {% assign documents = site.pages | where_exp: 'page', 'page.url contains currentVersionPath' | where: "toc", "true" | sort: 'weight' | unshift: h %}
@@ -49,7 +51,7 @@
 
             <div class="docs-actions">
 
-            <a id="edit" href="{{ page.github }}{{ page.name }}"><img src="{{ "/images/github-teal.svg" | relative_url }}" />Edit on GitHub</a>
+            <a id="edit" href="{{ page.github }}/{{ currentVersionBranch }}/{{ repopath }}"><img src="{{ "/images/github-teal.svg" | relative_url }}" />Edit on GitHub</a>
 
             </div>
 


### PR DESCRIPTION
Currently the edit on github link always assumes the document is available on master and also does not include full repo directory path. This updates to link to the specific release branch and also include any directory nesting that is present in the repo but not necessarily rendered in the website url.

This has been tested for both the `master` docs as well as release branches. This fixes for all releases listed on the docs site.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>