### PR TITLE
Update community meeting link

### DIFF
--- a/_includes/values.inc
+++ b/_includes/values.inc
@@ -5,5 +5,5 @@
 {% assign youtubeLink = "https://www.youtube.com/channel/UC19FgzMBMqBro361HbE46Fw" %}
 {% assign podcastLink = "https://www.youtube.com/playlist?list=PL510POnNVaaYFuK-B_SIUrpIonCtLVOzT" %}
 {% assign blogLink = "https://blog.crossplane.io/" %}
-{% assign communityMeetingLink = "https://github.com/crossplane/crossplane/#community-meeting" %}
+{% assign communityMeetingLink = "https://github.com/crossplane/crossplane/#get-involved" %}
 {% assign latestDocs = site.data.versions[0].path | append: '/' | relative_url %}


### PR DESCRIPTION
The current community meeting link is to a section in the README that no
longer exists. This updates it to the correct section.

Fixes https://github.com/crossplane/crossplane/issues/1655

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>