### PR TITLE
Set repopath to docs/README.md if empty

### DIFF
--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -7,6 +7,7 @@
 {% assign latestVersion = site.data.versions[0].version %}
 {% assign filepath = page.url | replace: currentVersionPath %}
 {% assign repopath = 'docs/' | append: filepath | remove: '.html' | append: '.md' %}
+{% if repopath == 'docs/.md' %}{% assign repopath = 'docs/README.md' %}{% endif %}
 
 {% include mkhash.inc title = 'Welcome' url = currentVersionPath %}
 {% assign documents = site.pages | where_exp: 'page', 'page.url contains currentVersionPath' | where: "toc", "true" | sort: 'weight' | unshift: h %}


### PR DESCRIPTION
Jekyll strips the path from the README page so we must add it back to
make sure the Edit on Github button has the correct link.

Fixes https://github.com/crossplane/crossplane/issues/1658

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>