### PR TITLE
Force latestVersion to v1.0 during v1.1 freeze

### DIFF
--- a/_includes/values.inc
+++ b/_includes/values.inc
@@ -7,5 +7,5 @@
 {% assign podcastLink = "https://www.youtube.com/playlist?list=PL510POnNVaaYFuK-B_SIUrpIonCtLVOzT" %}
 {% assign blogLink = "https://blog.crossplane.io/" %}
 {% assign communityMeetingLink = "https://github.com/crossplane/crossplane/#get-involved" %}
-{% assign latestDocs = site.data.versions[0].path | append: '/' | relative_url %}
+{% assign latestDocs = "/docs/v1.0" | append: '/' | relative_url %}
 {% assign cncfLink = "https://www.cncf.io/" %}

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -56,7 +56,7 @@
 
             </div>
 
-            {% if currentVersion == "master" %}
+            {% if currentVersion == "master" or currentVersion == "v1.1" %}
                 <div class="alert master">
                     <p>
                         <b>PLEASE NOTE</b>: This document applies to an <b>unreleased</b> version of Crossplane. It is strongly recommended that you only use official releases of Crossplane, as unreleased versions are subject to changes and incompatibilities that will not be supported in the official releases.


### PR DESCRIPTION
We hardcode v1.0 as latestVersion during v1.1 freeze so that the new
branch will not be the default shown to users visiting the site.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>