### PR TITLE
Set latestVersion to v1.0

### DIFF
--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -4,7 +4,7 @@
 {% assign currentVersion = url[2] %}
 {% assign currentVersionBranch = currentVersion | replace: 'v', 'release-' %}
 {% assign currentVersionPath = '/docs/' | append: currentVersion | append: '/' %}
-{% assign latestVersion = site.data.versions[0].version %}
+{% assign latestVersion = "v1.0" %}
 {% assign filepath = page.url | replace: currentVersionPath %}
 {% assign repopath = 'docs/' | append: filepath | remove: '.html' | append: '.md' %}
 {% if repopath == 'docs/.md' %}{% assign repopath = 'docs/README.md' %}{% endif %}


### PR DESCRIPTION
We hardcode v1.0 as latestVersion during v1.1 freeze so that the new
branch will not be the default shown to users visiting the site.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>