### PR TITLE
Use release-1.1 branch as latest docs

### DIFF
--- a/_includes/values.inc
+++ b/_includes/values.inc
@@ -7,5 +7,5 @@
 {% assign podcastLink = "https://www.youtube.com/playlist?list=PL510POnNVaaYFuK-B_SIUrpIonCtLVOzT" %}
 {% assign blogLink = "https://blog.crossplane.io/" %}
 {% assign communityMeetingLink = "https://github.com/crossplane/crossplane/#get-involved" %}
-{% assign latestDocs = "/docs/v1.0" | append: '/' | relative_url %}
+{% assign latestDocs = "/docs/v1.1" | append: '/' | relative_url %}
 {% assign cncfLink = "https://www.cncf.io/" %}

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -4,7 +4,7 @@
 {% assign currentVersion = url[2] %}
 {% assign currentVersionBranch = currentVersion | replace: 'v', 'release-' %}
 {% assign currentVersionPath = '/docs/' | append: currentVersion | append: '/' %}
-{% assign latestVersion = "v1.0" %}
+{% assign latestVersion = "v1.1" %}
 {% assign filepath = page.url | replace: currentVersionPath %}
 {% assign repopath = 'docs/' | append: filepath | remove: '.html' | append: '.md' %}
 {% if repopath == 'docs/.md' %}{% assign repopath = 'docs/README.md' %}{% endif %}
@@ -56,7 +56,7 @@
 
             </div>
 
-            {% if currentVersion == "master" or currentVersion == "v1.1" %}
+            {% if currentVersion == "master" %}
                 <div class="alert master">
                     <p>
                         <b>PLEASE NOTE</b>: This document applies to an <b>unreleased</b> version of Crossplane. It is strongly recommended that you only use official releases of Crossplane, as unreleased versions are subject to changes and incompatibilities that will not be supported in the official releases.


### PR DESCRIPTION
Updates latest and current docs to match release-1.1 for v1.1.0 release.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

See #87 and #88 for context.

Will remain in draft until the `v1.1.0` release is actually live.