### PR TITLE
update meta description to new headline copy too

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,7 +13,7 @@
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:site" content="https://crossplane.io" />
     <meta name="twitter:title" content="Crossplane" />
-    <meta name="twitter:description" content="Manage any infrastructure your applications need directly from Kubernetes" />
+    <meta name="twitter:description" content="Compose cloud infrastructure and services into custom platform APIs" />
     <meta name="twitter:image:src" content="https://crossplane.io/images/twitter-card_400x400.jpg" />
 
     {% include favicon.html %}


### PR DESCRIPTION
This was missed in #94, and updates the site's metadata "description" to match the same headline copy we put into the main page, e.g.: https://github.com/crossplane/crossplane.github.io/pull/94/files#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L12-R12

I noticed this while troubleshooting the crossplane.io outage today, when pasting crossplane.io into Slack it unfurls the URL and shows the old meta description copy still 😞 