### PR TITLE
use uniform body font for docs

### DIFF
--- a/css/docs.scss
+++ b/css/docs.scss
@@ -6,6 +6,7 @@
 
 body {
   font-size: 14px;
+  font-family: $body-font;
 }
 
 a:hover {


### PR DESCRIPTION
Hi there,

As I browse Crossplane's docs I notice that the font style isn't really uniform. For example, list and tabs are using Helvetica instead of Avenir Roman that is used throughout the rest of the docs.

This PR fixes that super minor issue.

Screenshots:
before:
![Screen Shot 2021-04-26 at 10 08 36 AM](https://user-images.githubusercontent.com/1574827/116023971-75a50480-a677-11eb-913c-e45db9041ae8.png)
![Screen Shot 2021-04-26 at 10 08 48 AM](https://user-images.githubusercontent.com/1574827/116023979-79d12200-a677-11eb-9d49-f8d8cc5b5565.png)

after:
![Screen Shot 2021-04-26 at 10 08 57 AM](https://user-images.githubusercontent.com/1574827/116023989-7fc70300-a677-11eb-9bb4-d3eaa62c6865.png)
![Screen Shot 2021-04-26 at 10 09 04 AM](https://user-images.githubusercontent.com/1574827/116023986-7e95d600-a677-11eb-9bb9-756191c9ce3c.png)
