### PR TITLE
Use release-1.2 branch as latest docs

### DIFF
--- a/_includes/values.inc
+++ b/_includes/values.inc
@@ -7,5 +7,5 @@
 {% assign podcastLink = "https://www.youtube.com/playlist?list=PL510POnNVaaYFuK-B_SIUrpIonCtLVOzT" %}
 {% assign blogLink = "https://blog.crossplane.io/" %}
 {% assign communityMeetingLink = "https://github.com/crossplane/crossplane/#get-involved" %}
-{% assign latestDocs = "/docs/v1.1" | append: '/' | relative_url %}
+{% assign latestDocs = "/docs/v1.2" | append: '/' | relative_url %}
 {% assign cncfLink = "https://www.cncf.io/" %}

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -4,7 +4,7 @@
 {% assign currentVersion = url[2] %}
 {% assign currentVersionBranch = currentVersion | replace: 'v', 'release-' %}
 {% assign currentVersionPath = '/docs/' | append: currentVersion | append: '/' %}
-{% assign latestVersion = "v1.1" %}
+{% assign latestVersion = "v1.2" %}
 {% assign filepath = page.url | replace: currentVersionPath %}
 {% assign repopath = 'docs/' | append: filepath | remove: '.html' | append: '.md' %}
 {% if repopath == 'docs/.md' %}{% assign repopath = 'docs/README.md' %}{% endif %}


### PR DESCRIPTION
Updates latest and current docs to match release-1.2 for v1.2.0 release.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Will remain in draft until `v1.2.0` is actually live.