### PR TITLE
Add twitter card to docs pages

### DIFF
--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -21,6 +21,13 @@
 
     <title>Crossplane Docs</title>
 
+    <!-- Twitter Cards -->
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:site" content="https://crossplane.io" />
+    <meta name="twitter:title" content="Crossplane" />
+    <meta name="twitter:description" content="Compose cloud infrastructure and services into custom platform APIs" />
+    <meta name="twitter:image:src" content="https://crossplane.io/images/twitter-card_400x400.jpg" />
+
     {% include favicon.html %}
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>


### PR DESCRIPTION
Updates doc pages header to include twitter card.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Fixes #103 

I used the same twitter card that we use on the main page, but we could be a little more creative and populate the description / url with the specific page data. This seems like at least a good start though.