### PR TITLE
Use release-1.3 branch as latest docs

### DIFF
--- a/_includes/values.inc
+++ b/_includes/values.inc
@@ -7,7 +7,7 @@
 {% assign podcastLink = "https://www.youtube.com/playlist?list=PL510POnNVaaYFuK-B_SIUrpIonCtLVOzT" %}
 {% assign blogLink = "https://blog.crossplane.io/" %}
 {% assign communityMeetingLink = "https://github.com/crossplane/crossplane/#get-involved" %}
-{% assign latestDocs = "/docs/v1.2" | append: '/' | relative_url %}
+{% assign latestDocs = "/docs/v1.3" | append: '/' | relative_url %}
 {% assign cncfLink = "https://www.cncf.io/" %}
 {% assign prodFormLink = "https://docs.google.com/forms/d/e/1FAIpQLSev-5clADSdkwi_wiFqBCAECeIoAQDE91chBbeWbvyTjRCeYg/viewform" %}
 {% assign infoMailToLink = "mailto:info@crossplane.io" %}

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -4,7 +4,7 @@
 {% assign currentVersion = url[2] %}
 {% assign currentVersionBranch = currentVersion | replace: 'v', 'release-' %}
 {% assign currentVersionPath = '/docs/' | append: currentVersion | append: '/' %}
-{% assign latestVersion = "v1.2" %}
+{% assign latestVersion = "v1.3" %}
 {% assign filepath = page.url | replace: currentVersionPath %}
 {% assign repopath = 'docs/' | append: filepath | remove: '.html' | append: '.md' %}
 {% if repopath == 'docs/.md' %}{% assign repopath = 'docs/README.md' %}{% endif %}


### PR DESCRIPTION
Updates latest and current docs to match release-1.3 for v1.3.0 release.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

*Note: I'll make sure this gets added as a step to the Crossplane release cut issue template.*