### PR TITLE
Do not index old documentation versions

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,10 +16,6 @@
     <meta name="twitter:description" content="Compose cloud infrastructure and services into custom platform APIs" />
     <meta name="twitter:image:src" content="https://crossplane.io/images/twitter-card_400x400.jpg" />
 
-  {% if currentVersion != latestVersion%}
-    <meta name="robots" content="noindex">
-  {% endif %}
-
     {% include favicon.html %}
 
     <link rel="stylesheet" href="{{ "/css/main.css" | relative_url }}" />

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -28,6 +28,11 @@
     <meta name="twitter:description" content="Compose cloud infrastructure and services into custom platform APIs" />
     <meta name="twitter:image:src" content="https://crossplane.io/images/twitter-card_400x400.jpg" />
 
+    {% if currentVersion != latestVersion %}
+    <!-- Do not index old documentation -->
+    <meta name="robots" content="noindex">
+    {% endif %}
+
     {% include favicon.html %}
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>


### PR DESCRIPTION
Updates old documentation pages to include a `noindex` directive to keep them out of search engine results. I verified locally by rendering docs and confirming that old versions do in fact include the `noindex` directive:

Fixes #107 

![noindex](https://user-images.githubusercontent.com/31777345/128711142-5a3fc7f8-fbec-4410-9751-4f0007d15aca.png)
