### PR TITLE
124 fix broken links

### DIFF
--- a/docs/master/getting-started/install-configure.md
+++ b/docs/master/getting-started/install-configure.md
@@ -494,8 +494,11 @@ you can [provision infrastructure].
 ## Start with a Downstream Distribution
 
 Upbound, the founders of Crossplane, maintains a free and open source downstream
-distribution of Crossplane which makes getting started with Crossplane easy. 
-Universal Crossplane, or UXP for short, connects to Upbound's hosted management 
+distribution of Crossplane which makes getting started with Crossplane easy.
+[Create an account] to get
+started. Once logged in, create a new hosted control plane and [connect to it] via
+the [up] CLI.
+Universal Crossplane, or UXP for short, connects to Upbound's hosted management
 console and Registry to make it easier to develop, debug, and manage Provider
 and Configuration packages.
 
@@ -535,6 +538,8 @@ Slack][Slack] and our community will highlight it here!</i>
 [Kind]: https://kind.sigs.k8s.io/docs/user/quick-start/
 [Crossplane packages]: ../concepts/packages.md
 [Slack]: http://slack.crossplane.io/
+[Create an account]: https://cloud.upbound.io/register
+[connect to it]: https://cloud.upbound.io/docs/upbound-cloud/connecting-to-control-planes
 [up]: https://github.com/upbound/up
 [Upbound documentation]: https://cloud.upbound.io/docs
 [Providers]: ../concepts/providers.md

--- a/docs/v1.4/getting-started/install-configure.md
+++ b/docs/v1.4/getting-started/install-configure.md
@@ -479,9 +479,9 @@ See [Uninstall] docs for cleaning up resources, packages, and Crossplane itself.
 [Helm]:https://docs.helm.sh/using_helm/
 [Kind]: https://kind.sigs.k8s.io/docs/user/quick-start/
 [Crossplane packages]: ../concepts/packages.md
-[connect to it]: https://cloud.upbound.io/docs/upbound-cloud/connecting-to-control-planes
 [Slack]: http://slack.crossplane.io/
 [Upbound Cloud]: https://upbound.io
 [Create an account]: https://cloud.upbound.io/register
+[connect to it]: https://cloud.upbound.io/docs/upbound-cloud/connecting-to-control-planes
 [up]: https://github.com/upbound/up
 [Upbound documentation]: https://cloud.upbound.io/docs

--- a/docs/v1.4/getting-started/install-configure.md
+++ b/docs/v1.4/getting-started/install-configure.md
@@ -32,7 +32,7 @@ instructions.
 
 Upbound, the founders of Crossplane, offers a free service for community members
 which makes getting started with Crossplane easy. [Create an account] to get
-started. Once logged in, create a new hosted control plane and connect to it via
+started. Once logged in, create a new hosted control plane and [connect to it] via
 the [up] CLI. See the [Upbound documentation] for more information.
 
 <i>Want see another hosted Crossplane service listed? Please [reach out on
@@ -479,6 +479,7 @@ See [Uninstall] docs for cleaning up resources, packages, and Crossplane itself.
 [Helm]:https://docs.helm.sh/using_helm/
 [Kind]: https://kind.sigs.k8s.io/docs/user/quick-start/
 [Crossplane packages]: ../concepts/packages.md
+[connect to it]: https://cloud.upbound.io/docs/upbound-cloud/connecting-to-control-planes
 [Slack]: http://slack.crossplane.io/
 [Upbound Cloud]: https://upbound.io
 [Create an account]: https://cloud.upbound.io/register

--- a/docs/v1.5/getting-started/install-configure.md
+++ b/docs/v1.5/getting-started/install-configure.md
@@ -32,7 +32,7 @@ instructions.
 
 Upbound, the founders of Crossplane, offers a free service for community members
 which makes getting started with Crossplane easy. [Create an account] to get
-started. Once logged in, create a new hosted control plane and connect to it via
+started. Once logged in, create a new hosted control plane and [connect to it] via
 the [up] CLI. See the [Upbound documentation] for more information.
 
 <i>Want see another hosted Crossplane service listed? Please [reach out on
@@ -482,5 +482,6 @@ See [Uninstall] docs for cleaning up resources, packages, and Crossplane itself.
 [Slack]: http://slack.crossplane.io/
 [Upbound Cloud]: https://upbound.io
 [Create an account]: https://cloud.upbound.io/register
+[connect to it]: https://cloud.upbound.io/docs/upbound-cloud/connecting-to-control-planes
 [up]: https://github.com/upbound/up
 [Upbound documentation]: https://cloud.upbound.io/docs

--- a/docs/v1.6/getting-started/install-configure.md
+++ b/docs/v1.6/getting-started/install-configure.md
@@ -494,8 +494,11 @@ you can [provision infrastructure].
 ## Start with a Downstream Distribution
 
 Upbound, the founders of Crossplane, maintains a free and open source downstream
-distribution of Crossplane which makes getting started with Crossplane easy. 
-Universal Crossplane, or UXP for short, connects to Upbound's hosted management 
+distribution of Crossplane which makes getting started with Crossplane easy.
+[Create an account] to get
+started. Once logged in, create a new hosted control plane and [connect to it] via
+the [up] CLI.
+Universal Crossplane, or UXP for short, connects to Upbound's hosted management
 console and Registry to make it easier to develop, debug, and manage Provider
 and Configuration packages.
 
@@ -535,6 +538,8 @@ Slack][Slack] and our community will highlight it here!</i>
 [Kind]: https://kind.sigs.k8s.io/docs/user/quick-start/
 [Crossplane packages]: ../concepts/packages.md
 [Slack]: http://slack.crossplane.io/
+[Create an account]: https://cloud.upbound.io/register
+[connect to it]: https://cloud.upbound.io/docs/upbound-cloud/connecting-to-control-planes
 [up]: https://github.com/upbound/up
 [Upbound documentation]: https://cloud.upbound.io/docs
 [Providers]: ../concepts/providers.md


### PR DESCRIPTION
Hi @jbw976,

I've added links addressing issue #124. Links point now to Upbound documentation and have the same wording in every version. Commits are created for every version separately to address changes/revert easier. Live [preview of the changes](https://piotr1215.github.io/crossplane.github.io/docs/v1.6/getting-started/install-configure.html) available on my Github pages.