### PR TITLE
Pin Jekyll image tag to 3 for local targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ run: _data/versions.json
 		-p 4000:4000 -p 4001:4001 \
 		-v="$(PWD)/vendor/bundle:/usr/local/bundle" \
 		-v "$(PWD):/srv/jekyll" \
-		jekyll/jekyll -- \
+		jekyll/jekyll:3 -- \
 		jekyll serve --livereload --livereload-port 4001
 
 run_docs_local: local_docs_dir _data/versions.json
@@ -16,7 +16,7 @@ run_docs_local: local_docs_dir _data/versions.json
 		-v="$(PWD)/vendor/bundle:/usr/local/bundle" \
 		-v "$(PWD):/srv/jekyll" \
 		-v "$(GOPATH)/src/github.com/crossplane/crossplane/docs:/srv/jekyll/$(LOCAL_DOCS_DIR)" \
-		jekyll/jekyll -- \
+		jekyll/jekyll:3 -- \
 		jekyll serve --livereload --livereload-port 4001
 	rm -d $(LOCAL_DOCS_DIR)
 
@@ -26,7 +26,7 @@ run_docs_local_incremental: local_docs_dir _data/versions.json
 		-v="$(PWD)/vendor/bundle:/usr/local/bundle" \
 		-v "$(PWD):/srv/jekyll" \
 		-v "$(GOPATH)/src/github.com/crossplane/crossplane/docs:/srv/jekyll/$(LOCAL_DOCS_DIR)" \
-		jekyll/jekyll -- \
+		jekyll/jekyll:3 -- \
 		jekyll serve --incremental --livereload --livereload-port 4001
 	rm -d $(LOCAL_DOCS_DIR)
 
@@ -35,7 +35,7 @@ build: _data/versions.json
 	docker run --rm -it \
 		-v="$(PWD)/vendor/bundle:/usr/local/bundle" \
 		-v "$(PWD):/srv/jekyll" \
-		jekyll/jekyll -- \
+		jekyll/jekyll:3 -- \
 		jekyll build
 
 # Build (output is in _site)
@@ -43,7 +43,7 @@ bundle_update: _data/versions.json
 	docker run --rm -it \
 		-v="$(PWD)/vendor/bundle:/usr/local/bundle" \
 		-v "$(PWD):/srv/jekyll" \
-		jekyll/jekyll -- \
+		jekyll/jekyll:3 -- \
 		bundle update
 
 # Push new changes to the live site


### PR DESCRIPTION
Using the `jekyll/jekyll:latest` tag causes [this issue](https://stackoverflow.com/questions/66113639/jekyll-serve-throws-no-implicit-conversion-of-hash-into-integer-error) due to the use of Ruby 3.

```
ruby 3.1.1p18 (2022-02-18 revision 53f5fc4236) [x86_64-linux-musl]
Configuration file: /srv/jekyll/_config.yml
            Source: /srv/jekyll
       Destination: /srv/jekyll/_site
 Incremental build: enabled
      Generating...
                    done in 25.52 seconds.
jekyll 3.9.0 | Error:  no implicit conversion of Hash into Integer
/usr/gem/gems/pathutil-0.16.2/lib/pathutil.rb:502:in `read': no implicit conversion of Hash into Integer (TypeError)
	from /usr/gem/gems/pathutil-0.16.2/lib/pathutil.rb:502:in `read'
	from /usr/gem/gems/jekyll-3.9.0/lib/jekyll/utils/platforms.rb:75:in `proc_version'
	from /usr/gem/gems/jekyll-3.9.0/lib/jekyll/utils/platforms.rb:40:in `bash_on_windows?'
	from /usr/gem/gems/jekyll-3.9.0/lib/jekyll/commands/build.rb:77:in `watch'
	from /usr/gem/gems/jekyll-3.9.0/lib/jekyll/commands/build.rb:43:in `process'
	from /usr/gem/gems/jekyll-3.9.0/lib/jekyll/commands/serve.rb:93:in `block in start'
	from /usr/gem/gems/jekyll-3.9.0/lib/jekyll/commands/serve.rb:93:in `each'
	from /usr/gem/gems/jekyll-3.9.0/lib/jekyll/commands/serve.rb:93:in `start'
	from /usr/gem/gems/jekyll-3.9.0/lib/jekyll/commands/serve.rb:75:in `block (2 levels) in init_with_program'
	from /usr/gem/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `block in execute'
	from /usr/gem/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `each'
	from /usr/gem/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `execute'
	from /usr/gem/gems/mercenary-0.3.6/lib/mercenary/program.rb:42:in `go'
	from /usr/gem/gems/mercenary-0.3.6/lib/mercenary.rb:19:in `program'
	from /usr/gem/gems/jekyll-3.9.0/exe/jekyll:15:in `<top (required)>'
	from /usr/local/bundle/bin/jekyll:27:in `load'
	from /usr/local/bundle/bin/jekyll:27:in `<main>'
make: *** [run_docs_local_incremental] Error 1
```

This PR pins to `jekyll/jekyll:3` in the Make targets to avoid this issue.