### PR TITLE
update OWNERS.md - add plumbis, remove connorchan

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -13,5 +13,9 @@ guidelines and responsibilities for the steering committee and maintainers.
 * Daniel Mangum <dan@upbound.io> ([hasheddan](https://github.com/hasheddan))
 * Jared Watts <jared@upbound.io> ([jbw976](https://github.com/jbw976))
 * Michael Goff <michael@upbound.io> ([thephred](https://github.com/thephred))
-* Connor Chan <connor@upbound.io> ([connorchan](https://github.com/connorchan))
 * Nic Cope <negz@upbound.io> ([negz](https://github.com/negz))
+* Pete Lumbis <pete@upbound.io> ([plumbis](https://github.com/plumbis))
+
+## Emeritus maintainers
+
+* Connor Chan <connor@upbound.io> ([connorchan](https://github.com/connorchan))


### PR DESCRIPTION
This PR updates the maintainers list for this https://github.com/crossplane/crossplane.github.io repo.

@plumbis has started contributing significantly to the Crossplane docs recently and will be leading an effort to update and overhaul the experience, of which the initial effort is being tracked in #149.  He has proven domain experience with technical documentation and will be an asset to the quality and velocity of this repository. Thank you for stepping into this position Pete! 🙇‍♂️ 

@connorchan is no longer actively working on the project and is being moved to Emeritus status.  Thank you @connorchan for all of the contributions you've made to this repo and project over the years.  Your efforts are appreciated! 🙇‍♂️ 