### PR TITLE
Updates the /docs redirect to always go to latest

### DIFF
--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -2,5 +2,5 @@
 title: crossplane
 weight: 401
 layout: redirect
-to: https://crossplane.io/docs/v1.9/
+docs_root: true
 ---

--- a/themes/crossplane/layouts/_default/redirect.html
+++ b/themes/crossplane/layouts/_default/redirect.html
@@ -1,1 +1,5 @@
+{{ if .Params.docs_root }}
+{{ partial "redirect" (dict "dest" (printf "https://crossplane.io/docs/v%s/" (string .Site.Params.latest) ) ) }}
+{{ else }}
 {{ partial "redirect" (dict "dest" .Params.to) }}
+{{ end }}


### PR DESCRIPTION
Updates the /docs landing page to indicate it should redirect to the latest version.

The redirect is handled by the redirect.html shortcode that is used to link to the external API docs.

Signed-off-by: Pete Lumbis <pete@upbound.io>