### PR TITLE
Make pages end in .html 

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -3,6 +3,7 @@ enableRobotsTXT: True
 languageCode: "en-us"
 title: "Crossplane"
 theme: "crossplane"
+uglyurls: true
 disableKinds:
   - taxonomy
   - term

--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -3,4 +3,5 @@ title: crossplane
 weight: 401
 layout: redirect
 docs_root: true
+url:  /docs/
 ---

--- a/content/docs/master/_index.md
+++ b/content/docs/master/_index.md
@@ -2,11 +2,13 @@
 title: "Overview"
 weight: -1
 toc_include: false
+aliases:
+    - /docs/master/index.html
 cascade:
     version: master
 ---
 
-![Crossplane](media/banner.png)
+![Crossplane](/docs/master/media/banner.png)
 
 Crossplane is an open source Kubernetes add-on that transforms your cluster into
 a **universal control plane**. Crossplane enables platform teams to assemble

--- a/content/docs/master/concepts/composition.md
+++ b/content/docs/master/concepts/composition.md
@@ -241,10 +241,10 @@ scenarios, including:
   take minutes to provision on-demand.
 
 [managed-resources]: {{<ref "managed-resources" >}}
-[xrs-and-mrs]: ../../media/composition-xrs-and-mrs.svg
+[xrs-and-mrs]: /docs/master/media/composition-xrs-and-mrs.svg
 [xr-ref]: {{<ref "../reference/composition" >}}
-[how-it-works]: ../../media/composition-how-it-works.svg
+[how-it-works]: /docs/master/media/composition-how-it-works.svg
 [crd-docs]: https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/
 [provider-kubernetes]: https://github.com/crossplane-contrib/provider-kubernetes
 [provider-helm]: https://github.com/crossplane-contrib/provider-helm
-[claims-and-xrs]: ../../media/composition-claims-and-xrs.svg
+[claims-and-xrs]: /docs/master/media/composition-claims-and-xrs.svg

--- a/content/docs/master/getting-started/_index.md
+++ b/content/docs/master/getting-started/_index.md
@@ -3,7 +3,7 @@ title: Getting Started
 weight: 4
 ---
 
-![Crossplane](../media/banner.png)
+![Crossplane](/docs/master/media/banner.png)
 
 Crossplane is an open source Kubernetes add-on that transforms your cluster into
 a **universal control plane**. Crossplane enables platform teams to assemble

--- a/content/docs/v1.7/_index.md
+++ b/content/docs/v1.7/_index.md
@@ -2,10 +2,12 @@
 title: "Overview"
 weight: -1
 toc_include: false
+aliases:
+    - /docs/v1.7/index.html
 cascade:
     version: 1.7
 ---
-![Crossplane](media/banner.png)
+![Crossplane](/docs/v1.7/media/banner.png)
 
 Crossplane is an open source Kubernetes add-on that transforms your cluster into
 a **universal control plane**. Crossplane enables platform teams to assemble

--- a/content/docs/v1.7/concepts/composition.md
+++ b/content/docs/v1.7/concepts/composition.md
@@ -245,10 +245,10 @@ scenarios, including:
   take minutes to provision on-demand.
 
 [managed-resources]: {{<ref "managed-resources" >}}
-[xrs-and-mrs]: ../../media/composition-xrs-and-mrs.svg
+[xrs-and-mrs]: /docs/v1.7/media/composition-xrs-and-mrs.svg
 [xr-ref]: {{<ref "../reference/composition" >}}
-[how-it-works]: ../../media/composition-how-it-works.svg
+[how-it-works]: /docs/v1.7/media/composition-how-it-works.svg
 [crd-docs]: https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/
 [provider-kubernetes]: https://github.com/crossplane-contrib/provider-kubernetes
 [provider-helm]: https://github.com/crossplane-contrib/provider-helm
-[claims-and-xrs]: ../../media/composition-claims-and-xrs.svg
+[claims-and-xrs]: /docs/v1.7/media/composition-claims-and-xrs.svg

--- a/content/docs/v1.7/getting-started/_index.md
+++ b/content/docs/v1.7/getting-started/_index.md
@@ -2,7 +2,7 @@
 title: "Getting Started"
 weight: 1
 ---
-![Crossplane](../media/banner.png)
+![Crossplane](/docs/v1.7/media/banner.png)
 
 Crossplane is an open source Kubernetes add-on that transforms your cluster into
 a **universal control plane**. Crossplane enables platform teams to assemble

--- a/content/docs/v1.8/_index.md
+++ b/content/docs/v1.8/_index.md
@@ -2,11 +2,13 @@
 title: "Overview"
 toc_include: false
 weight: -1
+aliases:
+    - /docs/v1.8/index.html
 cascade:
     version: 1.8
 ---
 
-![Crossplane](media/banner.png)
+![Crossplane](/docs/v1.8/media/banner.png)
 
 Crossplane is an open source Kubernetes add-on that transforms your cluster into
 a **universal control plane**. Crossplane enables platform teams to assemble

--- a/content/docs/v1.8/concepts/composition.md
+++ b/content/docs/v1.8/concepts/composition.md
@@ -241,10 +241,10 @@ scenarios, including:
   take minutes to provision on-demand.
 
 [managed-resources]: {{<ref "managed-resources" >}}
-[xrs-and-mrs]: ../media/composition-xrs-and-mrs.svg
+[xrs-and-mrs]: /docs/v1.8/media/composition-xrs-and-mrs.svg
 [xr-ref]: {{<ref "../reference/composition" >}}
-[how-it-works]: ../media/composition-how-it-works.svg
+[how-it-works]: /docs/v1.8/media/composition-how-it-works.svg
 [crd-docs]: https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/
 [provider-kubernetes]: https://github.com/crossplane-contrib/provider-kubernetes
 [provider-helm]: https://github.com/crossplane-contrib/provider-helm
-[claims-and-xrs]: ../media/composition-claims-and-xrs.svg
+[claims-and-xrs]: /docs/v1.8/media/composition-claims-and-xrs.svg

--- a/content/docs/v1.8/getting-started/_index.md
+++ b/content/docs/v1.8/getting-started/_index.md
@@ -6,7 +6,7 @@ cascade:
     version: 1.8
 ---
 
-![Crossplane](../media/banner.png)
+![Crossplane](/docs/v1.8/media/banner.png)
 
 Crossplane is an open source Kubernetes add-on that transforms your cluster into
 a **universal control plane**. Crossplane enables platform teams to assemble

--- a/content/docs/v1.9/_index.md
+++ b/content/docs/v1.9/_index.md
@@ -3,12 +3,12 @@ title: "Overview"
 weight: -1
 toc_include: false
 aliases:
-    - /docs
+    - /docs/v1.9/index.html
 cascade:
     version: 1.9
 ---
 
-![Crossplane](media/banner.png)
+![Crossplane](/docs/v1.9/media/banner.png)
 
 Crossplane is an open source Kubernetes add-on that transforms your cluster into
 a **universal control plane**. Crossplane enables platform teams to assemble

--- a/content/docs/v1.9/concepts/composition.md
+++ b/content/docs/v1.9/concepts/composition.md
@@ -241,10 +241,10 @@ scenarios, including:
   take minutes to provision on-demand.
 
 [managed-resources]: {{<ref "managed-resources" >}}
-[xrs-and-mrs]: ../../media/composition-xrs-and-mrs.svg
+[xrs-and-mrs]: /docs/v1.9/media/composition-xrs-and-mrs.svg
 [xr-ref]: {{<ref "../reference/composition" >}}
-[how-it-works]: ../../media/composition-how-it-works.svg
+[how-it-works]: /docs/v1.9/media/composition-how-it-works.svg
 [crd-docs]: https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/
 [provider-kubernetes]: https://github.com/crossplane-contrib/provider-kubernetes
 [provider-helm]: https://github.com/crossplane-contrib/provider-helm
-[claims-and-xrs]: ../../media/composition-claims-and-xrs.svg
+[claims-and-xrs]: /docs/v1.9/media/composition-claims-and-xrs.svg

--- a/content/docs/v1.9/getting-started/_index.md
+++ b/content/docs/v1.9/getting-started/_index.md
@@ -6,7 +6,7 @@ cascade:
     version: 1.9
 ---
 
-![Crossplane](../media/banner.png)
+![Crossplane](/docs/v1.9/media/banner.png)
 
 Crossplane is an open source Kubernetes add-on that transforms your cluster into
 a **universal control plane**. Crossplane enables platform teams to assemble

--- a/themes/crossplane/layouts/_default/redirect.html
+++ b/themes/crossplane/layouts/_default/redirect.html
@@ -1,5 +1,5 @@
 {{ if .Params.docs_root }}
-{{ partial "redirect" (dict "dest" (printf "https://crossplane.io/docs/v%s/" (string .Site.Params.latest) ) ) }}
+{{ partial "redirect" (dict "dest" (printf "https://crossplane.io/docs/v%s.html" (string .Site.Params.latest) ) ) }}
 {{ else }}
 {{ partial "redirect" (dict "dest" .Params.to) }}
 {{ end }}

--- a/themes/crossplane/layouts/partials/footer.html
+++ b/themes/crossplane/layouts/partials/footer.html
@@ -5,7 +5,7 @@
     </div>
     <div class="links sm-hidden">
       <a href='{{ .Site.Params.twitterLink }}'>Twitter</a>
-      <a href="{{ (printf "/v%s/" (string .Site.Params.latest)) | absURL }}">Documentation</a>
+      <a href="{{ (printf "/docs/v%s/" (string .Site.Params.latest)) | absURL }}">Documentation</a>
       <a href='{{ .Site.Params.githubLink }}'>GitHub</a>
       <a href='{{ .Site.Params.slackLink }}'>Slack Channel</a>
       <a href='{{ .Site.Params.youtubeLink }}'>YouTube</a>

--- a/themes/crossplane/layouts/partials/top-nav.html
+++ b/themes/crossplane/layouts/partials/top-nav.html
@@ -21,7 +21,7 @@
         <a href="{{ (printf "/docs/v%s/" (string .Site.Params.latest)) | absURL }}">Documentation</a>
       </li>
       <li>
-        <a href="{{"/community" | absURL }}/">Community</a>
+        <a href="{{"/community.html" | absURL }}/">Community</a>
       </li>
       <li>
         <a href="{{ .Site.Params.slackLink }}">Slack <span class="md-hidden">Channel</span></a>


### PR DESCRIPTION
The Jekyll based site had pages ending in `.html`, which Hugo doesn't do by default for SEO reasons.

This change creates pages with `.html` endings. This is required because Github Pages does not allow for server side redirects/rewrites. When #98 is resolved this should be rolled back and the solution should be done on the server side.