### PR TITLE
Fix alert box for older versions

### DIFF
--- a/themes/crossplane/layouts/_default/list.html
+++ b/themes/crossplane/layouts/_default/list.html
@@ -7,7 +7,7 @@
 
     <div class="docs-content">
         {{- partial "docs/github-edit.html" . -}}
-        {{- partial "docs/version-alert.html"  -}}
+        {{- partial "docs/version-alert.html" . -}}
         <h1>{{.Title }}</h1>
         {{ .Content }}
     </div>

--- a/themes/crossplane/layouts/_default/single.html
+++ b/themes/crossplane/layouts/_default/single.html
@@ -7,7 +7,7 @@
 
     <div class="docs-content">
         {{- partial "docs/github-edit.html" . -}}
-        {{- partial "docs/version-alert.html" -}}
+        {{- partial "docs/version-alert.html" . -}}
         <h1>{{.Title }}</h1>
         {{ .Content }}
     </div>


### PR DESCRIPTION
In the scramble to fix the deployment on Friday a template was modified that causes the alert on pages that aren't $latest to not show up. 

This passes the correct context to the partial page that checks the versions and renders the alert as necessary. 