### PR TITLE
add placeholder shortcodes 

### DIFF
--- a/themes/crossplane/layouts/shortcodes/hint.html
+++ b/themes/crossplane/layouts/shortcodes/hint.html
@@ -1,0 +1,16 @@
+{{ $type := default "note" (.Get "type") }}
+{{ $icon := .Get "icon" }}
+{{ $title := default ($type | title) (.Get "title") }}
+
+
+<blockquote class="gdoc-hint {{ $type | lower }}">
+  <div class="gdoc-hint__title flex align-center">
+    {{- with $icon -}}
+      <svg class="gdoc-icon {{ . }}"><use xlink:href="#{{ . }}"></use></svg>
+      <span>{{ $title }}</span>
+    {{- else -}}
+      <i class="fa {{ $type | lower }}" title="{{ $title }}"></i>
+    {{- end -}}
+  </div>
+  <div class="gdoc-hint__text">{{ .Inner | $.Page.RenderString }}</div>
+</blockquote>

--- a/themes/crossplane/layouts/shortcodes/hover.html
+++ b/themes/crossplane/layouts/shortcodes/hover.html
@@ -1,0 +1,37 @@
+{{- $rand_id := now.UnixNano -}}
+{{- if not (.Get "label") -}}
+{{- errorf "\n\nNo \"label\" element for {{< hover >}} tag on %s\n\n\n" .Position -}}
+{{- end -}}
+{{- if not (.Get "line") -}}
+{{- errorf "\n\nNo \"line\" number element for {{< hover >}} tag on %s \n\n\n" .Position -}}
+{{- end -}}
+<code><highlight-term id="{{$rand_id}}" data-label={{.Get "label" }} data-line={{.Get "line" }}>{{ .Inner }}</highlight-term></code>
+{{/*
+How to Use
+
+Create a normal code fence with triple ticks.
+```shell
+
+
+add a goldmark attribute to set a label for JS to key on.
+```shell {label="zzxxzz"}
+
+Put the code nomally.
+```shell {label="zzxxzz"}
+cat <<EOF | kubectl apply -f -
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-aws
+spec:
+  package: xpkg.upbound.io/upbound/provider-aws:v0.15.0
+  packagePullSecrets:
+    - name: package-pull-secret
+EOF
+```
+
+Now, for the keyword you want to be a hoverover use the shortcode. Do not put the command in backticks.
+This would be text around {{< hover label="zzxxzz" line="4">}}kind: Provider{{< /hover >}} the command.
+
+Provide the label of the code block and the line number to highlight.
+*/}}

--- a/themes/crossplane/layouts/shortcodes/include.html
+++ b/themes/crossplane/layouts/shortcodes/include.html
@@ -1,0 +1,18 @@
+{{ $file := .Get "file" }}
+{{ $page := .Site.GetPage $file }}
+{{ $type := .Get "type" }}
+{{ $language := .Get "language" }}
+{{ $options :=.Get "options" }}
+
+
+<div class="gdoc-include">
+  {{- if (.Get "language") -}}
+    {{- highlight ($file | readFile) $language (default "linenos=table" $options) -}}
+  {{- else if eq $type "html" -}}
+    {{- $file | readFile | safeHTML -}}
+  {{- else if eq $type "page" -}}
+    {{- with $page }}{{ .Content }}{{ end -}}
+  {{- else -}}
+    {{- $file | readFile | $.Page.RenderString -}}
+  {{- end -}}
+</div>


### PR DESCRIPTION
Shortcodes for multiple functionality placed as holders for the upcoming design and to make it easier to contribute Upbound documentation to Community docs.

Signed-off-by: Pete Lumbis <pete@upbound.io>