### PR TITLE
ensure include file exists or error

### DIFF
--- a/themes/crossplane/layouts/shortcodes/include.html
+++ b/themes/crossplane/layouts/shortcodes/include.html
@@ -4,6 +4,11 @@
 {{ $language := .Get "language" }}
 {{ $options :=.Get "options" }}
 
+{{ if eq $type "page" }}
+  {{ if not $page }}
+    {{ errorf "Couldn't find include file %s in page %s" $file .Position }}
+  {{ end }}
+{{ end }}
 
 <div class="gdoc-include">
   {{- if (.Get "language") -}}


### PR DESCRIPTION
Resolves #170 

Attempting to start hugo with an `include` shortcode for a file that doesn't exist (or incorrect path) will generate an error message during build:

```shell
Start building sites …
hugo v0.101.0-466fa43c16709b4483689930a4f9ac8add5c9f66+extended darwin/amd64 BuildDate=2022-06-16T07:09:16Z VendorInfo=gohugoio
ERROR 2022/10/20 16:22:51 Couldn't find include file child_page.md in page "/Users/plumbis/git/docs/content/contributing.md:391:1"
Error: Error building site: logged 1 error(s)
```


Signed-off-by: Pete Lumbis <pete@upbound.io>