### PR TITLE
Corrects the check to see if this doc is for the latest version. 

### DIFF
--- a/themes/crossplane/layouts/partials/docs/version-alert.html
+++ b/themes/crossplane/layouts/partials/docs/version-alert.html
@@ -10,7 +10,7 @@
         Documentation for other releases can be found by using the version selector in the top right of any doc page.
     </strong>
 </div>
-{{- else if lt .Page.Params.version .Site.Params.latest -}}
+{{- else if ne .Page.Params.version .Site.Params.latest -}}
 <div class="alert old">
     <p>
         <b>PLEASE NOTE</b>: This document applies to version {{ .Page.Params.version }} and not to the latest release {{.Site.Params.latest}}


### PR DESCRIPTION
In #165 we changed the version param from a float to a string. The check for printing an alert that the current page isn't the latest release wasn't changed to cover strings instead of floats.

Signed-off-by: Pete Lumbis <pete@upbound.io>