### PR TITLE
Change wording for Github link to `Contribute on GitHub`

### DIFF
--- a/themes/crossplane/layouts/partials/top-nav.html
+++ b/themes/crossplane/layouts/partials/top-nav.html
@@ -14,7 +14,7 @@
     <ul class="links">
       <li>
         <a href="{{ .Site.Params.githubLink  }}">
-          <span class="md-hidden">Get Started on</span> GitHub
+          <span class="md-hidden">Contribute on</span> GitHub
         </a>
       </li>
       <li>


### PR DESCRIPTION
This could be confusing for first time visitors, as there is another path for 'Getting started', which is `Documentation > Getting Started`, which links [here](https://crossplane.io/docs/v1.10/getting-started.html). The GitHub repo itself as resources to contribute, but not on 'how to get started with Crossplane'.

I don't have data for this confusion happening often, but I know of one instance of a user that ended up on the wrong page.

So the new wording should separate the link to Github and the link to Documentation a bit more and lead potential contributors to Github and users to the Documentation page.