### PR TITLE
fix bash syntax error

### DIFF
--- a/netlify_build.sh
+++ b/netlify_build.sh
@@ -9,8 +9,7 @@ sed -i "s/^\s*version: \"$LATEST_VER\"//g" content/latest/_index.md
 sed -i 's/# writeStats: true/writeStats: true/g' config.yaml
 cat config.yaml
 
-if [ $CONTEXT = "production"]
-then
+if [ "$CONTEXT" = "production" ]; then
 hugo --minify --baseURL https://docs.crossplane.io/
 else
 hugo --minify --baseURL $DEPLOY_URL


### PR DESCRIPTION
Previous bash script had a syntax error. 

Tested the fix by running the script on an ubuntu 20.04 system (note: this can't be tested on macOS because of Mac's version of sed)

I can't verify that `$CONTEXT` will work as expected, since it's a netlify environmental variable. 
