### PR TITLE
Change info on installing packages offline

### DIFF
--- a/content/master/concepts/packages.md
+++ b/content/master/concepts/packages.md
@@ -78,34 +78,12 @@ crossplane-stable/crossplane \
 
 ### Install offline
 
-Crossplane installs packages from a local package cache. By
-default the Crossplane package cache is an 
-[emptyDir volume](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir). 
+Installing Crossplane packages offline requires a local container registry like 
+[Harbor](https://goharbor.io/) to host the packages. Crossplane only
+supports installing packages from a container registry. 
 
-Configure Crossplane to use a 
-[PersistentVolumeClaim](https://kubernetes.io/docs/concepts/storage/persistent-volumes/)
-to use a storage location containing the Configuration image. Read more about
-configuring the Crossplane Pod settings in the 
-[Crossplane install documentation]({{<ref "../software/install#customize-the-crossplane-helm-chart">}}).
-
-Provide the name of the Configuration's `.xpkg` file and set 
-{{<hover label="offline" line="7">}}packagePullPolicy: Never{{</hover>}}.
-
-For example, to install a locally stored version of 
-Upbound AWS reference platform set the 
-{{<hover label="offline" line="6">}}package{{</hover>}} to the local filename
-and set the Configuration's
-{{<hover label="offline" line="7">}}packagePullPolicy: Never{{</hover>}}.
-
-```yaml {label="offline"}
-apiVersion: pkg.crossplane.io/v1
-kind: Configuration
-metadata:
-  name: offline-platform-ref-aws
-spec:
-  package: platform-ref-aws
-  packagePullPolicy: Never
-```
+Crossplane doesn't support installing packages directly from Kubernetes
+volumes.
 
 ### Installation options
 

--- a/content/master/concepts/providers.md
+++ b/content/master/concepts/providers.md
@@ -118,33 +118,12 @@ crossplane-stable/crossplane \
 
 ### Install offline
 
-Crossplane installs packages from a local package cache. By
-default the Crossplane package cache is an 
-[emptyDir volume](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir). 
+Installing Crossplane Providers offline requires a local container registry like 
+[Harbor](https://goharbor.io/) to host Provider packages. Crossplane only
+supports installing Provider packages from a container registry. 
 
-Configure Crossplane to use a 
-[PersistentVolumeClaim](https://kubernetes.io/docs/concepts/storage/persistent-volumes/)
-to use a storage location containing the Provider image. Read more about
-configuring the Crossplane Pod settings in the 
-[Crossplane install documentation]({{<ref "../software/install#customize-the-crossplane-helm-chart">}}).
-
-Provide the name of the Provider's `.xpkg` file and set 
-{{<hover label="offline" line="7">}}packagePullPolicy: Never{{</hover>}}.
-
-For example, to install a locally stored version of Provider AWS set the 
-{{<hover label="offline" line="6">}}package{{</hover>}} to the local filename
-and set the Provider's 
-{{<hover label="offline" line="7">}}packagePullPolicy: Never{{</hover>}}.
-
-```yaml {label="offline"}
-apiVersion: pkg.crossplane.io/v1
-kind: Provider
-metadata:
-  name: offline-provider-aws
-spec:
-  package: provider-aws
-  packagePullPolicy: Never
-```
+Crossplane doesn't support installing Provider packages directly from Kubernetes
+volumes.
 
 ### Installation options
 

--- a/content/master/release-notes/docs.md
+++ b/content/master/release-notes/docs.md
@@ -12,6 +12,17 @@ removed: 🗑️
 moved: 🗺️
 -->
 
+## March 14, 2024
+
+### Removed content 🗑️
+
+Removed information on installing Crossplane 
+[Providers]({{<ref "../concepts/providers#install-offline">}}) and 
+[Packages]({{<ref "../concepts/packages#install-offline">}}) offline using
+the local package cache. Installing via the local package cache isn't intended
+to be user facing and the recommended offline install method is with a private
+registry. 
+
 ## February 22, 2024
 
 ### Updated content 🏗️

--- a/content/v1.14/concepts/packages.md
+++ b/content/v1.14/concepts/packages.md
@@ -69,34 +69,12 @@ crossplane-stable/crossplane \
 
 ### Install offline
 
-Crossplane installs packages from a local package cache. By
-default the Crossplane package cache is an 
-[emptyDir volume](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir). 
+Installing Crossplane packages offline requires a local container registry like 
+[Harbor](https://goharbor.io/) to host the packages. Crossplane only
+supports installing packages from a container registry. 
 
-Configure Crossplane to use a 
-[PersistentVolumeClaim](https://kubernetes.io/docs/concepts/storage/persistent-volumes/)
-to use a storage location containing the Configuration image. Read more about
-configuring the Crossplane Pod settings in the 
-[Crossplane install documentation]({{<ref "../software/install#customize-the-crossplane-helm-chart">}}).
-
-Provide the name of the Configuration's `.xpkg` file and set 
-{{<hover label="offline" line="7">}}packagePullPolicy: Never{{</hover>}}.
-
-For example, to install a locally stored version of 
-Upbound AWS reference platform set the 
-{{<hover label="offline" line="6">}}package{{</hover>}} to the local filename
-and set the Configuration's
-{{<hover label="offline" line="7">}}packagePullPolicy: Never{{</hover>}}.
-
-```yaml {label="offline"}
-apiVersion: pkg.crossplane.io/v1
-kind: Configuration
-metadata:
-  name: offline-platform-ref-aws
-spec:
-  package: platform-ref-aws
-  packagePullPolicy: Never
-```
+Crossplane doesn't support installing packages directly from Kubernetes
+volumes.
 
 ### Installation options
 

--- a/content/v1.14/concepts/providers.md
+++ b/content/v1.14/concepts/providers.md
@@ -109,33 +109,12 @@ crossplane-stable/crossplane \
 
 ### Install offline
 
-Crossplane installs packages from a local package cache. By
-default the Crossplane package cache is an 
-[emptyDir volume](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir). 
+Installing Crossplane Providers offline requires a local container registry like 
+[Harbor](https://goharbor.io/) to host Provider packages. Crossplane only
+supports installing Provider packages from a container registry. 
 
-Configure Crossplane to use a 
-[PersistentVolumeClaim](https://kubernetes.io/docs/concepts/storage/persistent-volumes/)
-to use a storage location containing the Provider image. Read more about
-configuring the Crossplane Pod settings in the 
-[Crossplane install documentation]({{<ref "../software/install#customize-the-crossplane-helm-chart">}}).
-
-Provide the name of the Provider's `.xpkg` file and set 
-{{<hover label="offline" line="7">}}packagePullPolicy: Never{{</hover>}}.
-
-For example, to install a locally stored version of Provider AWS set the 
-{{<hover label="offline" line="6">}}package{{</hover>}} to the local filename
-and set the Provider's 
-{{<hover label="offline" line="7">}}packagePullPolicy: Never{{</hover>}}.
-
-```yaml {label="offline"}
-apiVersion: pkg.crossplane.io/v1
-kind: Provider
-metadata:
-  name: offline-provider-aws
-spec:
-  package: provider-aws
-  packagePullPolicy: Never
-```
+Crossplane doesn't support installing Provider packages directly from Kubernetes
+volumes.
 
 ### Installation options
 

--- a/content/v1.14/release-notes/docs.md
+++ b/content/v1.14/release-notes/docs.md
@@ -12,6 +12,17 @@ removed: 🗑️
 moved: 🗺️
 -->
 
+## March 14, 2024
+
+### Removed content 🗑️
+
+Removed information on installing Crossplane 
+[Providers]({{<ref "../concepts/providers#install-offline">}}) and 
+[Packages]({{<ref "../concepts/packages#install-offline">}}) offline using
+the local package cache. Installing via the local package cache isn't intended
+to be user facing and the recommended offline install method is with a private
+registry. 
+
 ## December 1, 2023
 
 ### New features 🎉

--- a/content/v1.15/concepts/packages.md
+++ b/content/v1.15/concepts/packages.md
@@ -78,34 +78,12 @@ crossplane-stable/crossplane \
 
 ### Install offline
 
-Crossplane installs packages from a local package cache. By
-default the Crossplane package cache is an 
-[emptyDir volume](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir). 
+Installing Crossplane packages offline requires a local container registry like 
+[Harbor](https://goharbor.io/) to host the packages. Crossplane only
+supports installing packages from a container registry. 
 
-Configure Crossplane to use a 
-[PersistentVolumeClaim](https://kubernetes.io/docs/concepts/storage/persistent-volumes/)
-to use a storage location containing the Configuration image. Read more about
-configuring the Crossplane Pod settings in the 
-[Crossplane install documentation]({{<ref "../software/install#customize-the-crossplane-helm-chart">}}).
-
-Provide the name of the Configuration's `.xpkg` file and set 
-{{<hover label="offline" line="7">}}packagePullPolicy: Never{{</hover>}}.
-
-For example, to install a locally stored version of 
-Upbound AWS reference platform set the 
-{{<hover label="offline" line="6">}}package{{</hover>}} to the local filename
-and set the Configuration's
-{{<hover label="offline" line="7">}}packagePullPolicy: Never{{</hover>}}.
-
-```yaml {label="offline"}
-apiVersion: pkg.crossplane.io/v1
-kind: Configuration
-metadata:
-  name: offline-platform-ref-aws
-spec:
-  package: platform-ref-aws
-  packagePullPolicy: Never
-```
+Crossplane doesn't support installing packages directly from Kubernetes
+volumes.
 
 ### Installation options
 

--- a/content/v1.15/concepts/providers.md
+++ b/content/v1.15/concepts/providers.md
@@ -118,33 +118,12 @@ crossplane-stable/crossplane \
 
 ### Install offline
 
-Crossplane installs packages from a local package cache. By
-default the Crossplane package cache is an 
-[emptyDir volume](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir). 
+Installing Crossplane Providers offline requires a local container registry like 
+[Harbor](https://goharbor.io/) to host Provider packages. Crossplane only
+supports installing Provider packages from a container registry. 
 
-Configure Crossplane to use a 
-[PersistentVolumeClaim](https://kubernetes.io/docs/concepts/storage/persistent-volumes/)
-to use a storage location containing the Provider image. Read more about
-configuring the Crossplane Pod settings in the 
-[Crossplane install documentation]({{<ref "../software/install#customize-the-crossplane-helm-chart">}}).
-
-Provide the name of the Provider's `.xpkg` file and set 
-{{<hover label="offline" line="7">}}packagePullPolicy: Never{{</hover>}}.
-
-For example, to install a locally stored version of Provider AWS set the 
-{{<hover label="offline" line="6">}}package{{</hover>}} to the local filename
-and set the Provider's 
-{{<hover label="offline" line="7">}}packagePullPolicy: Never{{</hover>}}.
-
-```yaml {label="offline"}
-apiVersion: pkg.crossplane.io/v1
-kind: Provider
-metadata:
-  name: offline-provider-aws
-spec:
-  package: provider-aws
-  packagePullPolicy: Never
-```
+Crossplane doesn't support installing Provider packages directly from Kubernetes
+volumes.
 
 ### Installation options
 

--- a/content/v1.15/release-notes/docs.md
+++ b/content/v1.15/release-notes/docs.md
@@ -12,6 +12,17 @@ removed: 🗑️
 moved: 🗺️
 -->
 
+## March 14, 2024
+
+### Removed content 🗑️
+
+Removed information on installing Crossplane 
+[Providers]({{<ref "../concepts/providers#install-offline">}}) and 
+[Packages]({{<ref "../concepts/packages#install-offline">}}) offline using
+the local package cache. Installing via the local package cache isn't intended
+to be user facing and the recommended offline install method is with a private
+registry. 
+
 ## February 22, 2024
 
 ### Updated content 🏗️


### PR DESCRIPTION
Changes the instructions for installing provider and config packages offline from using the local package cache to using a local registry.

The decision was made because using the local cache is very specific to the implementation details of the package cache and is subject to change in the future without notice. 