### PR TITLE
Clarify development mode listens to grpc cnx locally

### DIFF
--- a/content/v1.16/guides/write-a-composition-function-in-python.md
+++ b/content/v1.16/guides/write-a-composition-function-in-python.md
@@ -562,7 +562,7 @@ hatch run development
 ```
 
 {{<hint "warning">}}
-`hatch run development` runs the function without encryption or authentication.
+`hatch run development` runs the function, and listen to incoming grpc request on port 9443 without encryption or authentication.
 Only use it during testing and development.
 {{</hint>}}
 


### PR DESCRIPTION
<!--
Thanks for contributing to the docs! 

For information about local previews with Hugo read the contributing getting started guide:
https://docs.crossplane.io/contribute/contribute/

For information about Hugo's features like tabs and hint boxes read the styling features guide:
https://docs.crossplane.io/contribute/features/

For information on using Vale and testing locally read our Using Vale guide:
https://docs.crossplane.io/contribute/vale/

Need more help? Join the Crossplane Slack and ask in the #documentation channel.
https://slack.crossplane.io/
-->