### PR TITLE
Add link to Crossplane release process from extension release guide

### DIFF
--- a/content/master/guides/extensions-release-process.md
+++ b/content/master/guides/extensions-release-process.md
@@ -30,6 +30,12 @@ For more information about Crossplane packages, review the
 [xpkg concepts]({{<ref "../packages" >}}).
 {{< /hint >}}
 
+{{< hint "note" >}}
+This guide focuses on building and releasing Crossplane extensions. The release
+process for the core Crossplane software is available in the
+[`crossplane/release`](https://github.com/crossplane/release) repository.
+{{< /hint >}}
+
 ## Typical workflow
 
 A typical GitHub workflow definition to build and release an extension

--- a/content/v2.0/guides/extensions-release-process.md
+++ b/content/v2.0/guides/extensions-release-process.md
@@ -30,6 +30,12 @@ For more information about Crossplane packages, review the
 [xpkg concepts]({{<ref "../packages" >}}).
 {{< /hint >}}
 
+{{< hint "note" >}}
+This guide focuses on building and releasing Crossplane extensions. The release
+process for the core Crossplane software is available in the
+[`crossplane/release`](https://github.com/crossplane/release) repository.
+{{< /hint >}}
+
 ## Typical workflow
 
 A typical GitHub workflow definition to build and release an extension


### PR DESCRIPTION
This PR simply makes the Crossplane release process in https://github.com/crossplane/release more discoverable by adding a hint box to the "Releasing Crossplane Extensions" guide. Folks visiting that guide will now more easily find where to get information about releasing the core Crossplane software, in addition to the extension release information on that page.

This PR is related to graduation due diligence.