### PR TITLE
docs: add circuit breaker metrics counters

### DIFF
--- a/content/master/guides/metrics.md
+++ b/content/master/guides/metrics.md
@@ -55,4 +55,7 @@ prometheus.io/scrape: "true"
 | {{<hover label="crossplane_managed_resource_first_time_to_readiness_seconds_bucket" line="27">}}crossplane_managed_resource_first_time_to_readiness_seconds_bucket{{</hover>}} | The time it took for a managed resource to become ready first time after creation |  |
 | {{<hover label="crossplane_managed_resource_first_time_to_reconcile_seconds_bucket" line="28">}}crossplane_managed_resource_first_time_to_reconcile_seconds_bucket{{</hover>}} | The time it took to detect a managed resource by the controller |  |
 | {{<hover label="upjet_resource_ttr_bucket" line="29">}}upjet_resource_ttr_bucket{{</hover>}} | Measures in seconds the `time-to-readiness` `(TTR)` for managed resources |  |
+| {{<hover label="circuit_breaker_opens_total" line="30">}}circuit_breaker_opens_total{{</hover>}} | Total number of times the XR watch circuit breaker opened |  |
+| {{<hover label="circuit_breaker_closes_total" line="31">}}circuit_breaker_closes_total{{</hover>}} | Total number of times the XR watch circuit breaker closed again |  |
+| {{<hover label="circuit_breaker_events_total" line="32">}}circuit_breaker_events_total{{</hover>}} | Total number of watched events handled by the XR circuit breaker | Labeled by outcome (`Allowed`, `HalfOpenAllowed`, `Dropped`); deletion events skip the breaker. |
 {{</table >}}


### PR DESCRIPTION
## Summary
- document the three XR circuit breaker Prometheus counters alongside the existing Crossplane metrics table

## Related issues
- Fixes [crossplane/crossplane#6850](https://github.com/crossplane/crossplane/issues/6850)
- PR [crossplane/crossplane#6854](https://github.com/crossplane/crossplane/pull/6854)

## Testing
- I ran `hugo server` and ensured it formats correctly