### PR TITLE
Fix LUA healthcheck in ArgoCD guide

### DIFF
--- a/content/master/guides/crossplane-with-argo-cd.md
+++ b/content/master/guides/crossplane-with-argo-cd.md
@@ -112,7 +112,6 @@ data:
             if condition.status == "True" then
               health_status.status = "Healthy"
               health_status.message = "Resource is up-to-date."
-              return health_status
             end
           end
         end
@@ -179,7 +178,6 @@ data:
             if condition.status == "True" then
               health_status.status = "Healthy"
               health_status.message = "Resource is up-to-date."
-              return health_status
             end
           end
         end

--- a/content/v1.20/guides/crossplane-with-argo-cd.md
+++ b/content/v1.20/guides/crossplane-with-argo-cd.md
@@ -106,7 +106,6 @@ data:
             if condition.status == "True" then
               health_status.status = "Healthy"
               health_status.message = "Resource is up-to-date."
-              return health_status
             end
           end
         end
@@ -173,7 +172,6 @@ data:
             if condition.status == "True" then
               health_status.status = "Healthy"
               health_status.message = "Resource is up-to-date."
-              return health_status
             end
           end
         end

--- a/content/v2.0-preview/guides/crossplane-with-argo-cd.md
+++ b/content/v2.0-preview/guides/crossplane-with-argo-cd.md
@@ -106,7 +106,6 @@ data:
             if condition.status == "True" then
               health_status.status = "Healthy"
               health_status.message = "Resource is up-to-date."
-              return health_status
             end
           end
         end
@@ -172,7 +171,6 @@ data:
             if condition.status == "True" then
               health_status.status = "Healthy"
               health_status.message = "Resource is up-to-date."
-              return health_status
             end
           end
         end

--- a/content/v2.0/guides/crossplane-with-argo-cd.md
+++ b/content/v2.0/guides/crossplane-with-argo-cd.md
@@ -112,7 +112,6 @@ data:
             if condition.status == "True" then
               health_status.status = "Healthy"
               health_status.message = "Resource is up-to-date."
-              return health_status
             end
           end
         end
@@ -179,7 +178,6 @@ data:
             if condition.status == "True" then
               health_status.status = "Healthy"
               health_status.message = "Resource is up-to-date."
-              return health_status
             end
           end
         end

--- a/content/v2.1/guides/crossplane-with-argo-cd.md
+++ b/content/v2.1/guides/crossplane-with-argo-cd.md
@@ -112,7 +112,6 @@ data:
             if condition.status == "True" then
               health_status.status = "Healthy"
               health_status.message = "Resource is up-to-date."
-              return health_status
             end
           end
         end
@@ -179,7 +178,6 @@ data:
             if condition.status == "True" then
               health_status.status = "Healthy"
               health_status.message = "Resource is up-to-date."
-              return health_status
             end
           end
         end


### PR DESCRIPTION
Fixes https://github.com/crossplane/crossplane/issues/6569 after the healthcheck is implemented and used in ArgoCD as a default healthcheck for XP resources.

Early return in status.condition if condition.type is Ready and condition.status == "True" has led to ArgoCD incorrectly notyfing about status of MRs if the state has changed from healthy to unhealthy for example during spec.forProvider change that would lead to recreation of the MR

ArgoCD health status without the fix:
<img width="1996" height="1264" alt="image" src="https://github.com/user-attachments/assets/116be24d-128f-4d32-a9e0-ef6c85df19cd" />

ArgoCD health status with the fix:
<img width="1993" height="1244" alt="image" src="https://github.com/user-attachments/assets/e77bdb60-6965-44d1-b0ff-e1b13ceb2c4d" />
