### PR TITLE
fix(api): display all served crd versions seperatley in API documentation

### DIFF
--- a/themes/geekboot/layouts/partials/apiBuilder/getVersionAndSchema.html
+++ b/themes/geekboot/layouts/partials/apiBuilder/getVersionAndSchema.html
@@ -4,11 +4,19 @@
 {{ $deprecated := false }}
 
 {{ range .versions }}
-    {{ if index . "storage" }}
+    {{ if and (index . "storage") (not .deprecated) }}
         {{ $version = .name }}
         {{ $schema = .schema }}
         {{ $deprecated = .deprecated }}
-    {{ else if (and (index . "served") (not $version)) }}
+    {{ else if and (index . "served") (not .deprecated) (not $version) }}
+        {{ $version = .name }}
+        {{ $schema = .schema }}
+        {{ $deprecated = .deprecated }}
+    {{ else if and (index . "storage") (not $version) }}
+        {{ $version = .name }}
+        {{ $schema = .schema }}
+        {{ $deprecated = .deprecated }}
+    {{ else if and (index . "served") (not $version) }}
         {{ $version = .name }}
         {{ $schema = .schema }}
         {{ $deprecated = .deprecated }}

--- a/themes/geekboot/layouts/partials/apiBuilder/printGKVExpander.html
+++ b/themes/geekboot/layouts/partials/apiBuilder/printGKVExpander.html
@@ -8,11 +8,11 @@
 {{/* Collapse/Expand Button and Kind name */}}
 <div class="col col-xl-4 col-10 align-middle expand-buttons bigName-col">
     {{/* Plus/Minus Button */}}
-    <button class="expand-button collapsed align-middle" data-bs-toggle="collapse" data-bs-target="#{{$kind}}" type="button" aria-expanded="false" aria-controls="{{$kind}}"></button>
+    <button class="expand-button collapsed align-middle" data-bs-toggle="collapse" data-bs-target="#{{$kind}}-{{$version}}" type="button" aria-expanded="false" aria-controls="{{$kind}}-{{$version}}"></button>
 
     {{/* CRD name text */}}
-    <button class="crd-root collapsed align-middle" data-bs-toggle="collapse" data-bs-target="#{{$kind}}" type="button" aria-expanded="false" aria-controls="{{$kind}}">
-        <span class="align-middle {{ $kind }}"><a class="expansion-link" name="{{ $kind }}">{{ $kind }}{{ if $deprecated }} (deprecated){{ end }}</a></span>
+    <button class="crd-root collapsed align-middle" data-bs-toggle="collapse" data-bs-target="#{{$kind}}-{{$version}}" type="button" aria-expanded="false" aria-controls="{{$kind}}-{{$version}}">
+        <span class="align-middle {{ $kind }}"><a class="expansion-link" name="{{ $kind }}-{{$version}}">{{ $kind }}{{ if $deprecated }} (deprecated){{ end }}</a></span>
     </button>
 </div>
 

--- a/themes/geekboot/layouts/partials/crds.html
+++ b/themes/geekboot/layouts/partials/crds.html
@@ -22,47 +22,49 @@
             {{/* bigName is the kind length limit to change CSS styles when it needs to be truncated */}}
             {{ $bigName := partial "apiBuilder/checkBigName" $kind }}
 
+            {{/* Iterate over each served version and create separate entries */}}
+            {{ range $versionItem := $crdContent.spec.versions }}
+                {{ if $versionItem.served }}
+                    {{ $schema := $versionItem.schema.openAPIV3Schema }}
+                    {{ $version := $versionItem.name }}
+                    {{ $deprecated := $versionItem.deprecated }}
+                    {{ $description := $schema.description }}
 
-            {{/* Find the active version. We prefer the "storage: true" value but use "served: true" as a backup */}}
-            {{ $versionAndSchema := partial "apiBuilder/getVersionAndSchema" $crdContent.spec }}
-            {{ $schema := $versionAndSchema.schema.openAPIV3Schema }}
-            {{ $version := $versionAndSchema.version }}
-            {{ $deprecated := $versionAndSchema.deprecated }}
-            {{ $description := $schema.description }}
+                    {{/* The div containing the entire CRD information including the Expand All/Collapse All row */}}
+                    <div class="crd-root-row crd-container row align-middle bigName-row" data-kind="{{ $kind }}" data-group="{{ $group }}-{{ $kind}}" data-version="{{ $version }}-{{ $kind }}">
 
-            {{/* The div containing the entire CRD information including the Expand All/Collapse All row */}}
-            <div class="crd-root-row crd-container row align-middle bigName-row" data-kind="{{ $kind }}" data-group="{{ $group }}-{{ $kind}}" data-version="{{ $version }}-{{ $kind }}">
-
-                {{/* generate the GKV line to expand/collapse the CRD data */}}
-                {{ partial "apiBuilder/printGKVExpander" (dict  "group" $group "version" $version "kind" $kind "deprecated" $deprecated) }}
+                        {{/* generate the GKV line to expand/collapse the CRD data */}}
+                        {{ partial "apiBuilder/printGKVExpander" (dict  "group" $group "version" $version "kind" $kind "deprecated" $deprecated) }}
 
 
-                {{/* The container to show/hide with information related to the CRD */}}
-                <div class="collapse crd-expand {{$kind}}" id="{{$kind}}">
-                    {{/* Generate the "Download YAML" link */}}
-                    {{ partial "apiBuilder/downloadLink" (dict  "group" $group "version" $version "kind" $kind "downloadPath" $downloadPath) }}
+                        {{/* The container to show/hide with information related to the CRD */}}
+                        <div class="collapse crd-expand {{$kind}}" id="{{$kind}}-{{$version}}">
+                            {{/* Generate the "Download YAML" link */}}
+                            {{ partial "apiBuilder/downloadLink" (dict  "group" $group "version" $version "kind" $kind "downloadPath" $downloadPath) }}
 
-                    {{/* bigName-reset prevents the description from expanding into the x-scroll */}}
-                    <div class="description bigName-reset">
-                        {{ $description | markdownify}}
-                        <br />
+                            {{/* bigName-reset prevents the description from expanding into the x-scroll */}}
+                            <div class="description bigName-reset">
+                                {{ $description | markdownify}}
+                                <br />
+                            </div>
+
+                            {{/* Loop over each key inside the schema */}}
+                            {{ range $key, $contents := $schema.properties }}
+
+                                {{/* Skip irrelevant keys at the top level */}}
+                                {{ if not (in (slice "apiVersion" "description" "kind" "metadata") $key) }}
+                                    {{ partial "apiBuilder/processSpec" (dict "key" $key "contents" $contents "page" . "kind" $kind) }}
+                                {{ end }}
+
+                            {{ end }}
+
+                            {{/* Generate the "Return to top" link */}}
+                            {{ partialCached "apiBuilder/backToTopButton" . }}
+
+                        </div>
                     </div>
-
-                    {{/* Loop over each key inside the schema */}}
-                    {{ range $key, $contents := $schema.properties }}
-
-                        {{/* Skip irrelevant keys at the top level */}}
-                        {{ if not (in (slice "apiVersion" "description" "kind" "metadata") $key) }}
-                            {{ partial "apiBuilder/processSpec" (dict "key" $key "contents" $contents "page" . "kind" $kind) }}
-                        {{ end }}
-
-                    {{ end }}
-
-                    {{/* Generate the "Return to top" link */}}
-                    {{ partialCached "apiBuilder/backToTopButton" . }}
-
-                </div>
-            </div>
+                {{ end }}
+            {{ end }}
         {{ end}}
     </div>
 


### PR DESCRIPTION
The API documentation was only displaying one version per CRD resource, even when multiple versions were marked as `served: true`. 

For example, the CompositeResourceDefinition CRD has both v1 (deprecated, storage version) and v2 (active, non-storage version), but only v1 was being shown. 

This occurred because:
- The template logic selected a single "preferred" version using getVersionAndSchema
- The selection logic prioritized the storage version (v1) over newer served versions (v2)
- Only one entry was generated per CRD file
- Additionally, when attempting to show multiple versions, clicking on any version would expand/collapse ALL versions of that CRD because they shared the same DOM element ID.

<img width="1169" height="220" alt="image" src="https://github.com/user-attachments/assets/304d9ea6-4311-49e3-958e-84891b121ef3" />


<img width="1005" height="779" alt="image" src="https://github.com/user-attachments/assets/4032043e-cfc1-4c2d-b2b1-b56754bc2fcc" />

<img width="1185" height="760" alt="image" src="https://github.com/user-attachments/assets/9743e8a6-3cd3-4a40-a1f2-f2d5c59d9987" />

Fixes: #1011


<!--
Thanks for contributing to the docs! 

For information about local previews with Hugo read the contributing getting started guide:
https://docs.crossplane.io/contribute/contribute/

For information about Hugo's features like tabs and hint boxes read the styling features guide:
https://docs.crossplane.io/contribute/features/

For information on using Vale and testing locally read our Using Vale guide:
https://docs.crossplane.io/contribute/vale/

Need more help? Join the Crossplane Slack and ask in the #documentation channel.
https://slack.crossplane.io/
-->