### PR TITLE
backport connection details content to v2.1/v2.0

### DIFF
--- a/content/v2.0/composition/compositions.md
+++ b/content/v2.0/composition/compositions.md
@@ -58,7 +58,7 @@ A [composite resource]({{<ref "./composite-resources">}}) or XR is a custom API.
 You use two Crossplane types to create a new custom API:
 
 * A [Composite Resource Definition]({{<ref "./composite-resource-definitions">}})
-  (XRD) - Defines the XR's schema. 
+  (XRD) - Defines the XR's schema.
 * A Composition - This page. Configures how the XR creates other resources.
 {{</expand >}}
 
@@ -659,11 +659,11 @@ A function can change:
 * The `status` of the composite resource.
 * The `metadata` and `spec` of any composed resource.
 
-A function can also change the connection details and readiness of the composite
-resource. A function indicates that the composite resource is ready by telling
-Crossplane whether its composed resources are ready. When the function pipeline
-tells Crossplane that all composed resources are ready, Crossplane marks the
-composite resource as ready.
+A function can also change the readiness of the composite resource. A function
+indicates that the composite resource is ready by telling Crossplane whether its
+composed resources are ready. When the function pipeline tells Crossplane that
+all composed resources are ready, Crossplane marks the composite resource as
+ready.
 
 A function can't change:
 
@@ -812,20 +812,20 @@ spec:
       kind: Script
       script: |
         from crossplane.function import request
-        
+
         def compose(req, rsp):
             observed_xr = req.observed.composite.resource
-            
+
             # Access the required ConfigMap using the helper function
             config_map = request.get_required_resource(req, "app-config")
-            
+
             if not config_map:
                 # Fallback image if ConfigMap not found
                 image = "nginx:latest"
             else:
                 # Read image from ConfigMap data
                 image = config_map.get("data", {}).get("image", "nginx:latest")
-            
+
             # Create deployment with the configured image
             rsp.desired.resources["deployment"].resource.update({
                 "apiVersion": "apps/v1",
@@ -877,33 +877,33 @@ spec:
       kind: Script
       script: |
         from crossplane.function import request, response
-        
+
         def compose(req, rsp):
             observed_xr = req.observed.composite.resource
-            
+
             # Always request the ConfigMap to ensure stable requirements
             config_name = observed_xr["spec"].get("configName", "default-config")
             namespace = observed_xr["metadata"].get("namespace", "default")
-            
+
             response.require_resources(
-                rsp, 
+                rsp,
                 name="dynamic-config",
                 api_version="v1",
                 kind="ConfigMap",
                 match_name=config_name,
                 namespace=namespace
             )
-            
+
             # Check if we have the required ConfigMap
             config_map = request.get_required_resource(req, "dynamic-config")
-            
+
             if not config_map:
                 # ConfigMap not found yet - Crossplane will call us again
                 return
-            
+
             # ConfigMap found - use the image data to create deployment
             image = config_map.get("data", {}).get("image", "nginx:latest")
-            
+
             rsp.desired.resources["deployment"].resource.update({
                 "apiVersion": "apps/v1",
                 "kind": "Deployment",
@@ -955,12 +955,12 @@ context.
 ### Function response cache
 
 {{<hint "note" >}}
-Function response caching is an alpha feature. Enable it by setting the 
+Function response caching is an alpha feature. Enable it by setting the
 `--enable-function-response-cache` feature flag.
 {{< /hint >}}
 
-Crossplane can cache function responses to improve performance by reducing 
-repeated function calls. When enabled, Crossplane caches responses from 
+Crossplane can cache function responses to improve performance by reducing
+repeated function calls. When enabled, Crossplane caches responses from
 composition functions that include a time to live (TTL) value.
 
 The cache works by:
@@ -981,5 +981,5 @@ Control the cache behavior with these Crossplane pod arguments:
 - `--xfn-cache-max-ttl` - Maximum cache duration (default: 24 hours)
 
 The cache stores files in the `/cache/xfn/` directory in the Crossplane pod.
-For better performance, consider using an in-memory cache by mounting an 
+For better performance, consider using an in-memory cache by mounting an
 emptyDir volume with `medium: Memory`.

--- a/content/v2.0/whats-new/_index.md
+++ b/content/v2.0/whats-new/_index.md
@@ -171,9 +171,9 @@ deprecate and remove cluster scoped MRs at a future date.
 Read more about Crossplane v2's [backward compatibility](#backward-compatibility).
 {{</hint>}}
 
-Crossplane v2 also introduces 
-[managed resource definitions]({{<ref "../managed-resources/managed-resource-definitions">}}) 
-for selective activation of provider resources, reducing cluster overhead by 
+Crossplane v2 also introduces
+[managed resource definitions]({{<ref "../managed-resources/managed-resource-definitions">}})
+for selective activation of provider resources, reducing cluster overhead by
 installing only the managed resources you actually need.
 
 ## Compose any resource
@@ -250,7 +250,7 @@ spec:
 Operations support three modes:
 
 * **Operation** - Run once to completion
-* **CronOperation** - Run on a scheduled basis  
+* **CronOperation** - Run on a scheduled basis
 * **WatchOperation** - Run when resources change
 
 Operations can read existing resources and optionally change them. This enables
@@ -268,6 +268,7 @@ Crossplane v2 makes the following breaking changes:
 * It removes native patch and transform composition.
 * It removes the `ControllerConfig` type.
 * It removes support for external secret stores.
+* It removes composite resource connection details support.
 * It removes the default registry for Crossplane Packages.
 
 Crossplane deprecated native patch and transform composition in Crossplane
@@ -278,6 +279,10 @@ Crossplane deprecated the `ControllerConfig` type in v1.11. It's replaced by the
 
 Crossplane added external secret stores in v1.7. External secret stores have
 remained in alpha for over two years and are now unmaintained.
+
+Composite resources no longer have native connection details support. You
+can recreate this feature by composing your own connection details `Secret`
+as described in the [connection details composition guide]({{<ref "../guides/connection-details-composition">}}).
 
 Crossplane v2 drops the `--registry` flag that allowed users to specify a default
 registry value and now requires users to always specify a fully qualified URL when
@@ -299,9 +304,9 @@ Run `kubectl get pkg` to look for any packages that aren't fully qualified, then
 update or rebuild any Packages to use fully qualified images as needed.
 {{</hint>}}
 
-Crossplane v2 supports legacy v1-style XRs and MRs. Most users can upgrade from 
+Crossplane v2 supports legacy v1-style XRs and MRs. Most users can upgrade from
 v1.x to Crossplane v2 without breaking changes.
 
 Existing Compositions require minor updates to work with Crossplane v2
-style XRs and MRs. Follow the [Crossplane v2 upgrade guide]({{<ref "../guides/upgrade-to-crossplane-v2">}}) 
+style XRs and MRs. Follow the [Crossplane v2 upgrade guide]({{<ref "../guides/upgrade-to-crossplane-v2">}})
 for step-by-step migration instructions.

--- a/content/v2.1/composition/compositions.md
+++ b/content/v2.1/composition/compositions.md
@@ -58,7 +58,7 @@ A [composite resource]({{<ref "./composite-resources">}}) or XR is a custom API.
 You use two Crossplane types to create a new custom API:
 
 * A [Composite Resource Definition]({{<ref "./composite-resource-definitions">}})
-  (XRD) - Defines the XR's schema. 
+  (XRD) - Defines the XR's schema.
 * A Composition - This page. Configures how the XR creates other resources.
 {{</expand >}}
 
@@ -659,11 +659,11 @@ A function can change:
 * The `status` of the composite resource.
 * The `metadata` and `spec` of any composed resource.
 
-A function can also change the connection details and readiness of the composite
-resource. A function indicates that the composite resource is ready by telling
-Crossplane whether its composed resources are ready. When the function pipeline
-tells Crossplane that all composed resources are ready, Crossplane marks the
-composite resource as ready.
+A function can also change the readiness of the composite resource. A function
+indicates that the composite resource is ready by telling Crossplane whether its
+composed resources are ready. When the function pipeline tells Crossplane that
+all composed resources are ready, Crossplane marks the composite resource as
+ready.
 
 A function can't change:
 
@@ -812,20 +812,20 @@ spec:
       kind: Script
       script: |
         from crossplane.function import request
-        
+
         def compose(req, rsp):
             observed_xr = req.observed.composite.resource
-            
+
             # Access the required ConfigMap using the helper function
             config_map = request.get_required_resource(req, "app-config")
-            
+
             if not config_map:
                 # Fallback image if ConfigMap not found
                 image = "nginx:latest"
             else:
                 # Read image from ConfigMap data
                 image = config_map.get("data", {}).get("image", "nginx:latest")
-            
+
             # Create deployment with the configured image
             rsp.desired.resources["deployment"].resource.update({
                 "apiVersion": "apps/v1",
@@ -877,33 +877,33 @@ spec:
       kind: Script
       script: |
         from crossplane.function import request, response
-        
+
         def compose(req, rsp):
             observed_xr = req.observed.composite.resource
-            
+
             # Always request the ConfigMap to ensure stable requirements
             config_name = observed_xr["spec"].get("configName", "default-config")
             namespace = observed_xr["metadata"].get("namespace", "default")
-            
+
             response.require_resources(
-                rsp, 
+                rsp,
                 name="dynamic-config",
                 api_version="v1",
                 kind="ConfigMap",
                 match_name=config_name,
                 namespace=namespace
             )
-            
+
             # Check if we have the required ConfigMap
             config_map = request.get_required_resource(req, "dynamic-config")
-            
+
             if not config_map:
                 # ConfigMap not found yet - Crossplane will call us again
                 return
-            
+
             # ConfigMap found - use the image data to create deployment
             image = config_map.get("data", {}).get("image", "nginx:latest")
-            
+
             rsp.desired.resources["deployment"].resource.update({
                 "apiVersion": "apps/v1",
                 "kind": "Deployment",
@@ -955,12 +955,12 @@ context.
 ### Function response cache
 
 {{<hint "note" >}}
-Function response caching is an alpha feature. Enable it by setting the 
+Function response caching is an alpha feature. Enable it by setting the
 `--enable-function-response-cache` feature flag.
 {{< /hint >}}
 
-Crossplane can cache function responses to improve performance by reducing 
-repeated function calls. When enabled, Crossplane caches responses from 
+Crossplane can cache function responses to improve performance by reducing
+repeated function calls. When enabled, Crossplane caches responses from
 composition functions that include a time to live (TTL) value.
 
 The cache works by:
@@ -981,5 +981,5 @@ Control the cache behavior with these Crossplane pod arguments:
 - `--xfn-cache-max-ttl` - Maximum cache duration (default: 24 hours)
 
 The cache stores files in the `/cache/xfn/` directory in the Crossplane pod.
-For better performance, consider using an in-memory cache by mounting an 
+For better performance, consider using an in-memory cache by mounting an
 emptyDir volume with `medium: Memory`.

--- a/content/v2.1/whats-new/_index.md
+++ b/content/v2.1/whats-new/_index.md
@@ -171,9 +171,9 @@ deprecate and remove cluster scoped MRs at a future date.
 Read more about Crossplane v2's [backward compatibility](#backward-compatibility).
 {{</hint>}}
 
-Crossplane v2 also introduces 
-[managed resource definitions]({{<ref "../managed-resources/managed-resource-definitions">}}) 
-for selective activation of provider resources, reducing cluster overhead by 
+Crossplane v2 also introduces
+[managed resource definitions]({{<ref "../managed-resources/managed-resource-definitions">}})
+for selective activation of provider resources, reducing cluster overhead by
 installing only the managed resources you actually need.
 
 ## Compose any resource
@@ -250,7 +250,7 @@ spec:
 Operations support three modes:
 
 * **Operation** - Run once to completion
-* **CronOperation** - Run on a scheduled basis  
+* **CronOperation** - Run on a scheduled basis
 * **WatchOperation** - Run when resources change
 
 Operations can read existing resources and optionally change them. This enables
@@ -268,6 +268,7 @@ Crossplane v2 makes the following breaking changes:
 * It removes native patch and transform composition.
 * It removes the `ControllerConfig` type.
 * It removes support for external secret stores.
+* It removes composite resource connection details support.
 * It removes the default registry for Crossplane Packages.
 
 Crossplane deprecated native patch and transform composition in Crossplane
@@ -278,6 +279,10 @@ Crossplane deprecated the `ControllerConfig` type in v1.11. It's replaced by the
 
 Crossplane added external secret stores in v1.7. External secret stores have
 remained in alpha for over two years and are now unmaintained.
+
+Composite resources no longer have native connection details support. You
+can recreate this feature by composing your own connection details `Secret`
+as described in the [connection details composition guide]({{<ref "../guides/connection-details-composition">}}).
 
 Crossplane v2 drops the `--registry` flag that allowed users to specify a default
 registry value and now requires users to always specify a fully qualified URL when
@@ -299,9 +304,9 @@ Run `kubectl get pkg` to look for any packages that aren't fully qualified, then
 update or rebuild any Packages to use fully qualified images as needed.
 {{</hint>}}
 
-Crossplane v2 supports legacy v1-style XRs and MRs. Most users can upgrade from 
+Crossplane v2 supports legacy v1-style XRs and MRs. Most users can upgrade from
 v1.x to Crossplane v2 without breaking changes.
 
 Existing Compositions require minor updates to work with Crossplane v2
-style XRs and MRs. Follow the [Crossplane v2 upgrade guide]({{<ref "../guides/upgrade-to-crossplane-v2">}}) 
+style XRs and MRs. Follow the [Crossplane v2 upgrade guide]({{<ref "../guides/upgrade-to-crossplane-v2">}})
 for step-by-step migration instructions.


### PR DESCRIPTION
This is a follow up PR to https://github.com/crossplane/docs/pull/1035 that simply syncs (copies) the content from `master` to both `v2.1` and `v2.0` where this information is also relevant. 

There are no changes in the content from `master`, this is a simple copy operation.