### PR TITLE
chore: update OWNERS.md with current maintainer status

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -10,7 +10,6 @@ guidelines and responsibilities for the steering committee and maintainers.
 
 The Maintainers and Reviewers mirror the [crossplane/crossplane OWNERS](https://github.com/crossplane/crossplane/blob/main/OWNERS.md) with the following changes:
 
-* Jared Watts <jared@upbound.io> ([jbw976](https://github.com/jbw976)) as a maintainer
 * Pete Lumbis <pete@upbound.io> ([plumbis](https://github.com/plumbis)) as a maintainer
 * Michael Goff <michael@upbound.io> ([thephred](https://github.com/thephred)) as a maintainer
 * Jean du Plessis <jean@upbound.io> ([jeanduplessis](https://github.com/jeanduplessis)) as a maintainer
@@ -19,10 +18,10 @@ The Maintainers and Reviewers mirror the [crossplane/crossplane OWNERS](https://
 ## Maintainers
 
 * Nic Cope <negz@upbound.io> ([negz](https://github.com/negz))
-* Hasan Turken <hasan@upbound.io> ([turkenh](https://github.com/turkenh))
 * Bob Haddleton <bob.haddleton@nokia.com> ([bobh66](https://github.com/bobh66))
 * Philippe Scorsolini <philippe.scorsolini@upbound.io> ([phisco](https://github.com/phisco))
 * Jared Watts <jared@upbound.io> ([jbw976](https://github.com/jbw976))
+* Adam Wolfe Gordon <adam.wolfegordon@upbound.io> ([adamwg](https://github.com/adamwg))
 * Pete Lumbis <pete@upbound.io> ([plumbis](https://github.com/plumbis))
 * Michael Goff <michael@upbound.io> ([thephred](https://github.com/thephred))
 * Jean du Plessis <jean@upbound.io> ([jeanduplessis](https://github.com/jeanduplessis))
@@ -41,3 +40,4 @@ The Maintainers and Reviewers mirror the [crossplane/crossplane OWNERS](https://
 * Connor Chan <connor@upbound.io> ([connorchan](https://github.com/connorchan))
 * Daniel Mangum <dan@upbound.io> ([hasheddan](https://github.com/hasheddan))
 * Muvaffak Onus <monus@upbound.io> ([muvaf](https://github.com/muvaf))
+* Hasan Turken <hasan@upbound.io> ([turkenh](https://github.com/turkenh))


### PR DESCRIPTION
This PR updates the OWNERS.md file to match latest updates for Crossplane maintainer team, i.e. https://github.com/crossplane/crossplane/pull/7027. More details are available on that PR.