### PR TITLE
docs(packages): add docs about imageconfig runtime configref

### DIFF
--- a/content/master/packages/image-configs.md
+++ b/content/master/packages/image-configs.md
@@ -196,13 +196,13 @@ matching a pattern, regardless of how they're installed. This includes packages
 installed directly and packages installed as dependencies.
 
 The `spec.runtime` field allows you to specify a `DeploymentRuntimeConfig` that
-applies to all packages matching the image prefix. This is useful when you want
-to apply consistent runtime configurations across all packages from a particular
-registry or organization, including their dependencies.
+applies to all packages matching the image prefix. It allows you to apply
+consistent runtime configurations across all packages from a particular registry
+or organization, including their dependencies.
 
 ### Precedence
 
-When both an `ImageConfig` runtime and a package-level `runtimeConfigRef` are
+When both an `ImageConfig` runtime and a package level `runtimeConfigRef` are
 specified, the `ImageConfig` runtime takes precedence.
 
 ### Example


### PR DESCRIPTION
add docs about imageConfig `spec.runtime.configRef` 
Fixes: #1022
<!--
Thanks for contributing to the docs! 

For information about local previews with Hugo read the contributing getting started guide:
https://docs.crossplane.io/contribute/contribute/

For information about Hugo's features like tabs and hint boxes read the styling features guide:
https://docs.crossplane.io/contribute/features/

For information on using Vale and testing locally read our Using Vale guide:
https://docs.crossplane.io/contribute/vale/

Need more help? Join the Crossplane Slack and ask in the #documentation channel.
https://slack.crossplane.io/
-->