### PR TITLE
feat(algolia): add facets based on version for search

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_release.md
+++ b/.github/ISSUE_TEMPLATE/new_release.md
@@ -12,4 +12,5 @@ labels: release
 - [ ] Update `version` in the `_index.md` file of `/content/<new latest>` from `master` to the correct version.
 - [ ] Create a [new release/tag](https://github.com/crossplane/docs/releases/new) named `v<EOL version>-archive` to snapshot EOL'd docs.
 - [ ] Remove EOL'd docs version from "/content" directory and run `hugo` locally to check for broken links.
-- [ ] Trigger [Algolia Crawler](https://crawler.algolia.com/) after publishing to reindex results.
+- [ ] Update `pathsToMatch` in the Algolia crawler [config](https://crawler.algolia.com/admin/crawlers/b1863584-45fc-4117-831f-8d68e47b2e72/configuration/edit) to add the new version and remove the EOL version.
+- [ ] Trigger [Algolia Crawler](https://crawler.algolia.com/) after publishing to reindex results with the new version.

--- a/themes/geekboot/layouts/_default/baseof.html
+++ b/themes/geekboot/layouts/_default/baseof.html
@@ -14,6 +14,6 @@ color-theme="light">
     {{ end }}
 
     {{ partialCached "footer" . }}
-    {{ partialCached "scripts" . }}
+    {{ partial "scripts" . }}
   </body>
 </html>

--- a/themes/geekboot/layouts/partials/scripts.html
+++ b/themes/geekboot/layouts/partials/scripts.html
@@ -9,13 +9,63 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@docsearch/js@3"></script>
 <script>
+    {{ $cur_ver := "" }}
+    {{/* Only filter if we have a version parameter and it's not "0" (static pages) */}}
+    {{ if and .Page.Params.version (ne .Page.Params.version "0") }}
+        {{ if eq .Page.Params.version "master" }}
+            {{ $cur_ver = "0.0.0-master" }}
+        {{ else }}
+            {{ $cur_ver = .Page.Params.version }}
+        {{ end }}
+    {{ end }}
 
-    docsearch({
-    container: '#docSearch',
-    appId: '9UXKYX61NK',
-    indexName: 'crossplane',
-    apiKey: 'e07e181044d561f6a4cb7261931d980a',
-    placeholder: 'Search the docs'
+    const docSearchInstance = docsearch({
+        container: '#docSearch',
+        appId: '9UXKYX61NK',
+        indexName: 'crossplane',
+        apiKey: 'e07e181044d561f6a4cb7261931d980a',
+        placeholder: 'Search the docs',
+        searchParameters: {
+            attributesToRetrieve: ['hierarchy.lvl0', 'hierarchy.lvl1', 'hierarchy.lvl2', 'hierarchy.lvl3', 'hierarchy.lvl4', 'hierarchy.lvl5', 'hierarchy.lvl6', 'content', 'type', 'url', 'version']{{ if $cur_ver }},
+            facetFilters: [['version:{{ $cur_ver }}']]{{ end }}
+        },
+        transformItems(items) {
+            // Add version warning banner and badges after DOM renders
+            setTimeout(() => {
+                {{ if and $cur_ver (ne .Page.Params.version "master") (ne .Page.Params.version .Site.Params.latest) }}
+                // Add warning banner for old version
+                const dropdown = document.querySelector('.DocSearch-Dropdown-Container');
+                if (dropdown && !dropdown.hasAttribute('data-version-banner-added')) {
+                    const banner = document.createElement('div');
+                    banner.style.cssText = 'padding: 12px; margin: 0 0 12px 0; background: #fff3cd; color: #856404; border-left: 4px solid #ffc107; font-size: 0.875rem;';
+                    banner.innerHTML = '<strong>Searching in v{{ .Page.Params.version }}</strong><br>You are viewing an older version. Results are filtered to this version only. <a href="/v{{ .Site.Params.latest }}/" style="color: #856404; text-decoration: underline; font-weight: 600;">View v{{ .Site.Params.latest }}</a>';
+                    dropdown.insertBefore(banner, dropdown.firstChild);
+                    dropdown.setAttribute('data-version-banner-added', 'true');
+                }
+                {{ end }}
+
+                // Add version badges to each hit
+                items.forEach(item => {
+                    if (item.version && item.version !== '0') {
+                        const hitLink = document.querySelector(`.DocSearch-Hit a[href="${item.url}"]`);
+                        if (hitLink) {
+                            const container = hitLink.querySelector('.DocSearch-Hit-Container');
+                            if (container && !container.hasAttribute('data-version-set')) {
+                                const versionText = item.version === '0.0.0-master' ? 'master' : `v${item.version}`;
+                                const badge = document.createElement('div');
+                                badge.className = 'DocSearch-Hit-version';
+                                badge.textContent = versionText;
+                                badge.style.cssText = 'position: absolute; right: 8px; top: 50%; transform: translateY(-50%); font-size: 0.65rem; font-weight: 600; padding: 2px 6px; background: #5468ff; color: white; border-radius: 3px;';
+                                container.style.position = 'relative';
+                                container.appendChild(badge);
+                                container.setAttribute('data-version-set', 'true');
+                            }
+                        }
+                    }
+                });
+            }, 10);
+            return items;
+        }
     });
 
 </script>


### PR DESCRIPTION
When browsing older documentation versions (for example, v1.20), search results currently all content from latest....
This leads to confusion when users discover features or APIs in search results that don’t actually exist in the version they’re viewing.

This PR introduces version-aware search filtering using **Algolia** facet filters. https://www.algolia.com/doc/guides/managing-results/refine-results/faceting
Search results will be restricted to the documentation version the user is currently viewing.

- Added logic to detect the current page version via `.Page.Params.version`.
- Configured DocSearch to apply a `facetFilters` value dynamically:

```
['version:X.XX']
```

- Added special handling for the master version - uses `version:0.0.0-master`, which matches the existing meta tag convention where master is labeled `0.0.0-master` to keep it de-ranked in search

### Background
Each page already includes:
<meta name="docsearch:version" content="X.XX">

which the Algolia crawler indexes.

```
curl https://docs.crossplane.io/v2.0/composition/  | grep -A 10 "docsearch"
<meta name=docsearch:modified content='August 14, 2025'><meta name=docsearch:version content="2.0">
```

```
curl https://docs.crossplane.io/v1.20/concepts/  | grep -A 10 "docsearch"
<meta name=docsearch:modified content='May 21, 2025'><meta name=docsearch:version content="1.20">
```

### Required: Algolia configuration
After this PR is merged, someone with Algolia admin access must enable faceting:

- Open Algolia Dashboard
- Go to the **crossplane** index
- Navigate to Configuration → Facets
- Add:
searchable(version)
to Attributes for faceting

- Save


### Testing:

```
curl http://localhost:1313/v2.1/composition/ | grep -A 10 "docsearch"
...
<script>
    docsearch({
    container: '#docSearch',
    appId: 'xxx',
    indexName: 'crossplane',
    apiKey: 'xxxxx',
    placeholder: 'Search the docs',
    searchParameters: {
      facetFilters: ['version:2.1']
    }
    });
</script>
```

To verify this PR:
- Open any versioned docs page (for example, /v1.20/concepts/providers/)
- Open DevTools → Network
- Perform a search
- Inspect the request to algolia.net
```
{"requests":[{"query":"t","indexName":"crossplane","attributesToRetrieve":["hierarchy.lvl0","hierarchy.lvl1","hierarchy.lvl2","hierarchy.lvl3","hierarchy.lvl4","hierarchy.lvl5","hierarchy.lvl6","content","type","url"],"attributesToSnippet":["hierarchy.lvl1:10","hierarchy.lvl2:10","hierarchy.lvl3:10","hierarchy.lvl4:10","hierarchy.lvl5:10","hierarchy.lvl6:10","content:10"],"snippetEllipsisText":"…","highlightPreTag":"<mark>","highlightPostTag":"</mark>","hitsPerPage":20,"clickAnalytics":false,"facetFilters":["version:2.0"]}]}
```

we see the facetFilters

Fixes: #1008
<!--
Thanks for contributing to the docs! 

For information about local previews with Hugo read the contributing getting started guide:
https://docs.crossplane.io/contribute/contribute/

For information about Hugo's features like tabs and hint boxes read the styling features guide:
https://docs.crossplane.io/contribute/features/

For information on using Vale and testing locally read our Using Vale guide:
https://docs.crossplane.io/contribute/vale/

Need more help? Join the Crossplane Slack and ask in the #documentation channel.
https://slack.crossplane.io/
-->