### PR TITLE
fix(guides): import set correct atProvider path

### DIFF
--- a/content/v1.20/guides/import-existing-resources.md
+++ b/content/v1.20/guides/import-existing-resources.md
@@ -243,7 +243,7 @@ Copy any required parameter values from
 in {{<hover label="fc" line="9">}}spec.forProvider{{</hover>}}.
 
 {{< hint "tip" >}}
-Manually copy the important `spec.atProvider` values to `spec.forProvider`.
+Manually copy the important `status.atProvider` values to `spec.forProvider`.
 {{< /hint >}}
 
 ```yaml {label="fc"}

--- a/content/v2.0/guides/import-existing-resources.md
+++ b/content/v2.0/guides/import-existing-resources.md
@@ -170,7 +170,7 @@ Copy any required parameter values from
 in {{<hover label="fc" line="9">}}spec.forProvider{{</hover>}}.
 
 {{< hint "tip" >}}
-Manually copy the important `spec.atProvider` values to `spec.forProvider`.
+Manually copy the important `status.atProvider` values to `spec.forProvider`.
 {{< /hint >}}
 
 ```yaml {label="fc"}

--- a/content/v2.1/guides/import-existing-resources.md
+++ b/content/v2.1/guides/import-existing-resources.md
@@ -170,7 +170,7 @@ Copy any required parameter values from
 in {{<hover label="fc" line="9">}}spec.forProvider{{</hover>}}.
 
 {{< hint "tip" >}}
-Manually copy the important `spec.atProvider` values to `spec.forProvider`.
+Manually copy the important `status.atProvider` values to `spec.forProvider`.
 {{< /hint >}}
 
 ```yaml {label="fc"}


### PR DESCRIPTION
follow up for: https://github.com/crossplane/docs/pull/912 add the fix to our other active versions
<!--
Thanks for contributing to the docs! 

For information about local previews with Hugo read the contributing getting started guide:
https://docs.crossplane.io/contribute/contribute/

For information about Hugo's features like tabs and hint boxes read the styling features guide:
https://docs.crossplane.io/contribute/features/

For information on using Vale and testing locally read our Using Vale guide:
https://docs.crossplane.io/contribute/vale/

Need more help? Join the Crossplane Slack and ask in the #documentation channel.
https://slack.crossplane.io/
-->