### PR TITLE
docs: update Crossplane status to CNCF graduated

### DIFF
--- a/themes/geekboot/layouts/partials/footer.html
+++ b/themes/geekboot/layouts/partials/footer.html
@@ -53,7 +53,7 @@
                 class="cncf-footer py-3"
           />
         </a>
-        <p class="d-flex">We are a Cloud Native Computing Foundation incubating project.</p>
+        <p class="d-flex">We are a Cloud Native Computing Foundation graduated project.</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
This PR updates the footer content to reflect its current status as a "graduated project," replacing the former "incubating project" text
