### PR TITLE
Include condition for inactive MRD

### DIFF
--- a/content/master/guides/crossplane-with-argo-cd.md
+++ b/content/master/guides/crossplane-with-argo-cd.md
@@ -175,7 +175,7 @@ data:
           end
 
           if contains({"Ready", "Healthy", "Offered", "Established", "ValidPipeline", "RevisionHealthy"}, condition.type) then
-            if condition.status == "True" then
+            if condition.status == "True" or (condition.type == "Established" and condition.reason == "InactiveManagedResource") then
               health_status.status = "Healthy"
               health_status.message = "Resource is up-to-date."
             end

--- a/content/v2.0/guides/crossplane-with-argo-cd.md
+++ b/content/v2.0/guides/crossplane-with-argo-cd.md
@@ -175,7 +175,7 @@ data:
           end
 
           if contains({"Ready", "Healthy", "Offered", "Established", "ValidPipeline", "RevisionHealthy"}, condition.type) then
-            if condition.status == "True" then
+            if condition.status == "True" or (condition.type == "Established" and condition.reason == "InactiveManagedResource") then
               health_status.status = "Healthy"
               health_status.message = "Resource is up-to-date."
             end

--- a/content/v2.1/guides/crossplane-with-argo-cd.md
+++ b/content/v2.1/guides/crossplane-with-argo-cd.md
@@ -175,7 +175,7 @@ data:
           end
 
           if contains({"Ready", "Healthy", "Offered", "Established", "ValidPipeline", "RevisionHealthy"}, condition.type) then
-            if condition.status == "True" then
+            if condition.status == "True" or (condition.type == "Established" and condition.reason == "InactiveManagedResource") then
               health_status.status = "Healthy"
               health_status.message = "Resource is up-to-date."
             end

--- a/content/v2.2/guides/crossplane-with-argo-cd.md
+++ b/content/v2.2/guides/crossplane-with-argo-cd.md
@@ -175,7 +175,7 @@ data:
           end
 
           if contains({"Ready", "Healthy", "Offered", "Established", "ValidPipeline", "RevisionHealthy"}, condition.type) then
-            if condition.status == "True" then
+            if condition.status == "True" or (condition.type == "Established" and condition.reason == "InactiveManagedResource") then
               health_status.status = "Healthy"
               health_status.message = "Resource is up-to-date."
             end


### PR DESCRIPTION
Includes a condition in the Lua snippet for counting an inactive MRD as healthy.

Fixes #1058 
<!--
Thanks for contributing to the docs! 

For information about local previews with Hugo read the contributing getting started guide:
https://docs.crossplane.io/contribute/contribute/

For information about Hugo's features like tabs and hint boxes read the styling features guide:
https://docs.crossplane.io/contribute/features/

For information on using Vale and testing locally read our Using Vale guide:
https://docs.crossplane.io/contribute/vale/

Need more help? Join the Crossplane Slack and ask in the #documentation channel.
https://slack.crossplane.io/
-->