### PR TITLE
docs: use apiextensions.crossplane.io/v2 for XRD in v2 docs

### DIFF
--- a/content/master/cli/command-reference.md
+++ b/content/master/cli/command-reference.md
@@ -1011,7 +1011,7 @@ Apply a CEL rule with the
 inside the schema {{<hover label="celXRD" line="10" >}}spec{{</hover>}} object of an XRD.
 
 ```yaml {label="celXRD"}
-apiVersion: apiextensions.crossplane.io/v1
+apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata:
   name: myXR.crossplane.io

--- a/content/master/composition/composite-resource-definitions.md
+++ b/content/master/composition/composite-resource-definitions.md
@@ -138,7 +138,7 @@ label="xrdName" line="9">}}plural{{</hover>}} name
 {{<hover label="xrdName" line="6">}}example.org{{</hover>}}.
 
 ```yaml {label="xrdName",copy-lines="none"}
-apiVersion: apiextensions.crossplane.io/v1
+apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata:
   name: mydatabases.example.org
@@ -208,7 +208,7 @@ In this example, the key {{<hover label="schema" line="19">}}region{{</hover>}}
 is a {{<hover label="schema" line="20">}}string{{</hover>}}.
 
 ```yaml {label="schema",copy-lines="none"}
-apiVersion: apiextensions.crossplane.io/v1
+apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata:
   name: xdatabases.custom-api.example.org
@@ -276,7 +276,7 @@ In this example the XRD requires
 {{< hover label="required" line="21">}}size{{</hover>}} but
 {{< hover label="required" line="23">}}name{{</hover>}} is optional.
 ```yaml {label="required",copy-lines="none"}
-apiVersion: apiextensions.crossplane.io/v1
+apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata:
   name: xdatabases.custom-api.example.org
@@ -374,7 +374,7 @@ and
 {{<hover label="served" line="13" >}}referenceable: true{{</hover>}}.
 
 ```yaml {label="served"}
-apiVersion: apiextensions.crossplane.io/v1
+apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata:
   name: xdatabases.custom-api.example.org
@@ -457,7 +457,7 @@ A second version,
 {{<hover label="ver" line="31">}}size{{</hover>}}.
 
 ```yaml {label="ver",copy-lines="none"}
-apiVersion: apiextensions.crossplane.io/v1
+apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata:
   name: xdatabases.custom-api.example.org
@@ -549,7 +549,7 @@ Set a
 to set the default Composition.
 
 ```yaml {label="defaultComp",copy-lines="none"}
-apiVersion: apiextensions.crossplane.io/v1
+apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata:
   name: xdatabases.custom-api.example.org
@@ -580,7 +580,7 @@ to set the default Composition update policy for composite resources and using
 this XRD.
 
 ```yaml {label="compRev",copy-lines="none"}
-apiVersion: apiextensions.crossplane.io/v1
+apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata:
   name: xdatabases.custom-api.example.org
@@ -606,7 +606,7 @@ set
 {{<hover label="enforceComp" line="6">}}enforcedCompositionRef.name: myComposition{{</hover>}}.
 
 ```yaml {label="defaultComp",copy-lines="none"}
-apiVersion: apiextensions.crossplane.io/v1
+apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata:
   name: xdatabases.custom-api.example.org
@@ -650,7 +650,7 @@ View the conditions of a XRD under their `Status` with
 ```yaml {copy-lines="none"}
 kubectl describe xrd
 Name:         xpostgresqlinstances.database.starter.org
-API Version:  apiextensions.crossplane.io/v1
+API Version:  apiextensions.crossplane.io/v2
 Kind:         CompositeResourceDefinition
 # Removed for brevity
 Status:

--- a/content/master/composition/composite-resource-definitions.md
+++ b/content/master/composition/composite-resource-definitions.md
@@ -130,9 +130,7 @@ The XRD
 {{<hover label="xrdName" line="9">}}plural{{</hover>}} name, `.` (dot character),
 {{<hover label="xrdName" line="6">}}group{{</hover>}}.
 
-For example, {{<hover label="xrdName"
-line="4">}}mydatabases.example.org{{</hover>}} matches the {{<hover
-label="xrdName" line="9">}}plural{{</hover>}} name
+For example, {{<hover label="xrdName" line="4">}}mydatabases.example.org{{</hover>}} matches the {{<hover label="xrdName" line="9">}}plural{{</hover>}} name
 {{<hover label="xrdName" line="9">}}mydatabases{{</hover>}}, `.`
 {{<hover label="xrdName" line="6">}}group{{</hover>}} name,
 {{<hover label="xrdName" line="6">}}example.org{{</hover>}}.

--- a/content/master/composition/composite-resources.md
+++ b/content/master/composition/composite-resources.md
@@ -64,7 +64,7 @@ creates a custom API endpoint
 {{<hover label="xrd1" line="4">}}mydatabases.example.org{{</hover>}}.
 
 ```yaml {label="xrd1",copy-lines="none"}
-apiVersion: apiextensions.crossplane.io/v1
+apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata: 
   name: mydatabases.example.org

--- a/content/master/composition/composition-revisions.md
+++ b/content/master/composition/composition-revisions.md
@@ -169,7 +169,7 @@ spec:
 
 Apply the example XRD.
 ```yaml
-apiVersion: apiextensions.crossplane.io/v1
+apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata:
   name: myvpcs.aws.example.upbound.io

--- a/content/master/guides/function-patch-and-transform.md
+++ b/content/master/guides/function-patch-and-transform.md
@@ -533,7 +533,7 @@ spec:
 
 {{<expand "Reference CompositeResourceDefinition" >}}
 ```yaml {copy-lines="all"}
-apiVersion: apiextensions.crossplane.io/v1
+apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata:
   name: examples.example.org

--- a/content/v2.0/cli/command-reference.md
+++ b/content/v2.0/cli/command-reference.md
@@ -1011,7 +1011,7 @@ Apply a CEL rule with the
 inside the schema {{<hover label="celXRD" line="10" >}}spec{{</hover>}} object of an XRD.
 
 ```yaml {label="celXRD"}
-apiVersion: apiextensions.crossplane.io/v1
+apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata:
   name: myXR.crossplane.io

--- a/content/v2.0/composition/composite-resource-definitions.md
+++ b/content/v2.0/composition/composite-resource-definitions.md
@@ -138,7 +138,7 @@ label="xrdName" line="9">}}plural{{</hover>}} name
 {{<hover label="xrdName" line="6">}}example.org{{</hover>}}.
 
 ```yaml {label="xrdName",copy-lines="none"}
-apiVersion: apiextensions.crossplane.io/v1
+apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata:
   name: mydatabases.example.org
@@ -208,7 +208,7 @@ In this example, the key {{<hover label="schema" line="19">}}region{{</hover>}}
 is a {{<hover label="schema" line="20">}}string{{</hover>}}.
 
 ```yaml {label="schema",copy-lines="none"}
-apiVersion: apiextensions.crossplane.io/v1
+apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata:
   name: xdatabases.custom-api.example.org
@@ -276,7 +276,7 @@ In this example the XRD requires
 {{< hover label="required" line="21">}}size{{</hover>}} but
 {{< hover label="required" line="23">}}name{{</hover>}} is optional.
 ```yaml {label="required",copy-lines="none"}
-apiVersion: apiextensions.crossplane.io/v1
+apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata:
   name: xdatabases.custom-api.example.org
@@ -374,7 +374,7 @@ and
 {{<hover label="served" line="13" >}}referenceable: true{{</hover>}}.
 
 ```yaml {label="served"}
-apiVersion: apiextensions.crossplane.io/v1
+apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata:
   name: xdatabases.custom-api.example.org
@@ -457,7 +457,7 @@ A second version,
 {{<hover label="ver" line="31">}}size{{</hover>}}.
 
 ```yaml {label="ver",copy-lines="none"}
-apiVersion: apiextensions.crossplane.io/v1
+apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata:
   name: xdatabases.custom-api.example.org
@@ -549,7 +549,7 @@ Set a
 to set the default Composition.
 
 ```yaml {label="defaultComp",copy-lines="none"}
-apiVersion: apiextensions.crossplane.io/v1
+apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata:
   name: xdatabases.custom-api.example.org
@@ -580,7 +580,7 @@ to set the default Composition update policy for composite resources and using
 this XRD.
 
 ```yaml {label="compRev",copy-lines="none"}
-apiVersion: apiextensions.crossplane.io/v1
+apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata:
   name: xdatabases.custom-api.example.org
@@ -606,7 +606,7 @@ set
 {{<hover label="enforceComp" line="6">}}enforcedCompositionRef.name: myComposition{{</hover>}}.
 
 ```yaml {label="defaultComp",copy-lines="none"}
-apiVersion: apiextensions.crossplane.io/v1
+apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata:
   name: xdatabases.custom-api.example.org
@@ -650,7 +650,7 @@ View the conditions of a XRD under their `Status` with
 ```yaml {copy-lines="none"}
 kubectl describe xrd
 Name:         xpostgresqlinstances.database.starter.org
-API Version:  apiextensions.crossplane.io/v1
+API Version:  apiextensions.crossplane.io/v2
 Kind:         CompositeResourceDefinition
 # Removed for brevity
 Status:

--- a/content/v2.0/composition/composite-resource-definitions.md
+++ b/content/v2.0/composition/composite-resource-definitions.md
@@ -130,9 +130,7 @@ The XRD
 {{<hover label="xrdName" line="9">}}plural{{</hover>}} name, `.` (dot character),
 {{<hover label="xrdName" line="6">}}group{{</hover>}}.
 
-For example, {{<hover label="xrdName"
-line="4">}}mydatabases.example.org{{</hover>}} matches the {{<hover
-label="xrdName" line="9">}}plural{{</hover>}} name
+For example, {{<hover label="xrdName" line="4">}}mydatabases.example.org{{</hover>}} matches the {{<hover label="xrdName" line="9">}}plural{{</hover>}} name
 {{<hover label="xrdName" line="9">}}mydatabases{{</hover>}}, `.`
 {{<hover label="xrdName" line="6">}}group{{</hover>}} name,
 {{<hover label="xrdName" line="6">}}example.org{{</hover>}}.

--- a/content/v2.0/composition/composite-resources.md
+++ b/content/v2.0/composition/composite-resources.md
@@ -64,7 +64,7 @@ creates a custom API endpoint
 {{<hover label="xrd1" line="4">}}mydatabases.example.org{{</hover>}}.
 
 ```yaml {label="xrd1",copy-lines="none"}
-apiVersion: apiextensions.crossplane.io/v1
+apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata: 
   name: mydatabases.example.org

--- a/content/v2.0/composition/composition-revisions.md
+++ b/content/v2.0/composition/composition-revisions.md
@@ -169,7 +169,7 @@ spec:
 
 Apply the example XRD.
 ```yaml
-apiVersion: apiextensions.crossplane.io/v1
+apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata:
   name: myvpcs.aws.example.upbound.io

--- a/content/v2.0/guides/function-patch-and-transform.md
+++ b/content/v2.0/guides/function-patch-and-transform.md
@@ -533,7 +533,7 @@ spec:
 
 {{<expand "Reference CompositeResourceDefinition" >}}
 ```yaml {copy-lines="all"}
-apiVersion: apiextensions.crossplane.io/v1
+apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata:
   name: examples.example.org

--- a/content/v2.1/cli/command-reference.md
+++ b/content/v2.1/cli/command-reference.md
@@ -1011,7 +1011,7 @@ Apply a CEL rule with the
 inside the schema {{<hover label="celXRD" line="10" >}}spec{{</hover>}} object of an XRD.
 
 ```yaml {label="celXRD"}
-apiVersion: apiextensions.crossplane.io/v1
+apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata:
   name: myXR.crossplane.io

--- a/content/v2.1/composition/composite-resource-definitions.md
+++ b/content/v2.1/composition/composite-resource-definitions.md
@@ -138,7 +138,7 @@ label="xrdName" line="9">}}plural{{</hover>}} name
 {{<hover label="xrdName" line="6">}}example.org{{</hover>}}.
 
 ```yaml {label="xrdName",copy-lines="none"}
-apiVersion: apiextensions.crossplane.io/v1
+apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata:
   name: mydatabases.example.org
@@ -208,7 +208,7 @@ In this example, the key {{<hover label="schema" line="19">}}region{{</hover>}}
 is a {{<hover label="schema" line="20">}}string{{</hover>}}.
 
 ```yaml {label="schema",copy-lines="none"}
-apiVersion: apiextensions.crossplane.io/v1
+apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata:
   name: xdatabases.custom-api.example.org
@@ -276,7 +276,7 @@ In this example the XRD requires
 {{< hover label="required" line="21">}}size{{</hover>}} but
 {{< hover label="required" line="23">}}name{{</hover>}} is optional.
 ```yaml {label="required",copy-lines="none"}
-apiVersion: apiextensions.crossplane.io/v1
+apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata:
   name: xdatabases.custom-api.example.org
@@ -374,7 +374,7 @@ and
 {{<hover label="served" line="13" >}}referenceable: true{{</hover>}}.
 
 ```yaml {label="served"}
-apiVersion: apiextensions.crossplane.io/v1
+apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata:
   name: xdatabases.custom-api.example.org
@@ -457,7 +457,7 @@ A second version,
 {{<hover label="ver" line="31">}}size{{</hover>}}.
 
 ```yaml {label="ver",copy-lines="none"}
-apiVersion: apiextensions.crossplane.io/v1
+apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata:
   name: xdatabases.custom-api.example.org
@@ -549,7 +549,7 @@ Set a
 to set the default Composition.
 
 ```yaml {label="defaultComp",copy-lines="none"}
-apiVersion: apiextensions.crossplane.io/v1
+apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata:
   name: xdatabases.custom-api.example.org
@@ -580,7 +580,7 @@ to set the default Composition update policy for composite resources and using
 this XRD.
 
 ```yaml {label="compRev",copy-lines="none"}
-apiVersion: apiextensions.crossplane.io/v1
+apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata:
   name: xdatabases.custom-api.example.org
@@ -606,7 +606,7 @@ set
 {{<hover label="enforceComp" line="6">}}enforcedCompositionRef.name: myComposition{{</hover>}}.
 
 ```yaml {label="defaultComp",copy-lines="none"}
-apiVersion: apiextensions.crossplane.io/v1
+apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata:
   name: xdatabases.custom-api.example.org
@@ -650,7 +650,7 @@ View the conditions of a XRD under their `Status` with
 ```yaml {copy-lines="none"}
 kubectl describe xrd
 Name:         xpostgresqlinstances.database.starter.org
-API Version:  apiextensions.crossplane.io/v1
+API Version:  apiextensions.crossplane.io/v2
 Kind:         CompositeResourceDefinition
 # Removed for brevity
 Status:

--- a/content/v2.1/composition/composite-resource-definitions.md
+++ b/content/v2.1/composition/composite-resource-definitions.md
@@ -130,9 +130,7 @@ The XRD
 {{<hover label="xrdName" line="9">}}plural{{</hover>}} name, `.` (dot character),
 {{<hover label="xrdName" line="6">}}group{{</hover>}}.
 
-For example, {{<hover label="xrdName"
-line="4">}}mydatabases.example.org{{</hover>}} matches the {{<hover
-label="xrdName" line="9">}}plural{{</hover>}} name
+For example, {{<hover label="xrdName" line="4">}}mydatabases.example.org{{</hover>}} matches the {{<hover label="xrdName" line="9">}}plural{{</hover>}} name
 {{<hover label="xrdName" line="9">}}mydatabases{{</hover>}}, `.`
 {{<hover label="xrdName" line="6">}}group{{</hover>}} name,
 {{<hover label="xrdName" line="6">}}example.org{{</hover>}}.

--- a/content/v2.1/composition/composite-resources.md
+++ b/content/v2.1/composition/composite-resources.md
@@ -64,7 +64,7 @@ creates a custom API endpoint
 {{<hover label="xrd1" line="4">}}mydatabases.example.org{{</hover>}}.
 
 ```yaml {label="xrd1",copy-lines="none"}
-apiVersion: apiextensions.crossplane.io/v1
+apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata: 
   name: mydatabases.example.org

--- a/content/v2.1/composition/composition-revisions.md
+++ b/content/v2.1/composition/composition-revisions.md
@@ -169,7 +169,7 @@ spec:
 
 Apply the example XRD.
 ```yaml
-apiVersion: apiextensions.crossplane.io/v1
+apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata:
   name: myvpcs.aws.example.upbound.io

--- a/content/v2.1/guides/function-patch-and-transform.md
+++ b/content/v2.1/guides/function-patch-and-transform.md
@@ -533,7 +533,7 @@ spec:
 
 {{<expand "Reference CompositeResourceDefinition" >}}
 ```yaml {copy-lines="all"}
-apiVersion: apiextensions.crossplane.io/v1
+apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata:
   name: examples.example.org

--- a/content/v2.2/cli/command-reference.md
+++ b/content/v2.2/cli/command-reference.md
@@ -1011,7 +1011,7 @@ Apply a CEL rule with the
 inside the schema {{<hover label="celXRD" line="10" >}}spec{{</hover>}} object of an XRD.
 
 ```yaml {label="celXRD"}
-apiVersion: apiextensions.crossplane.io/v1
+apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata:
   name: myXR.crossplane.io

--- a/content/v2.2/composition/composite-resource-definitions.md
+++ b/content/v2.2/composition/composite-resource-definitions.md
@@ -138,7 +138,7 @@ label="xrdName" line="9">}}plural{{</hover>}} name
 {{<hover label="xrdName" line="6">}}example.org{{</hover>}}.
 
 ```yaml {label="xrdName",copy-lines="none"}
-apiVersion: apiextensions.crossplane.io/v1
+apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata:
   name: mydatabases.example.org
@@ -208,7 +208,7 @@ In this example, the key {{<hover label="schema" line="19">}}region{{</hover>}}
 is a {{<hover label="schema" line="20">}}string{{</hover>}}.
 
 ```yaml {label="schema",copy-lines="none"}
-apiVersion: apiextensions.crossplane.io/v1
+apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata:
   name: xdatabases.custom-api.example.org
@@ -276,7 +276,7 @@ In this example the XRD requires
 {{< hover label="required" line="21">}}size{{</hover>}} but
 {{< hover label="required" line="23">}}name{{</hover>}} is optional.
 ```yaml {label="required",copy-lines="none"}
-apiVersion: apiextensions.crossplane.io/v1
+apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata:
   name: xdatabases.custom-api.example.org
@@ -374,7 +374,7 @@ and
 {{<hover label="served" line="13" >}}referenceable: true{{</hover>}}.
 
 ```yaml {label="served"}
-apiVersion: apiextensions.crossplane.io/v1
+apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata:
   name: xdatabases.custom-api.example.org
@@ -457,7 +457,7 @@ A second version,
 {{<hover label="ver" line="31">}}size{{</hover>}}.
 
 ```yaml {label="ver",copy-lines="none"}
-apiVersion: apiextensions.crossplane.io/v1
+apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata:
   name: xdatabases.custom-api.example.org
@@ -549,7 +549,7 @@ Set a
 to set the default Composition.
 
 ```yaml {label="defaultComp",copy-lines="none"}
-apiVersion: apiextensions.crossplane.io/v1
+apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata:
   name: xdatabases.custom-api.example.org
@@ -580,7 +580,7 @@ to set the default Composition update policy for composite resources and using
 this XRD.
 
 ```yaml {label="compRev",copy-lines="none"}
-apiVersion: apiextensions.crossplane.io/v1
+apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata:
   name: xdatabases.custom-api.example.org
@@ -606,7 +606,7 @@ set
 {{<hover label="enforceComp" line="6">}}enforcedCompositionRef.name: myComposition{{</hover>}}.
 
 ```yaml {label="defaultComp",copy-lines="none"}
-apiVersion: apiextensions.crossplane.io/v1
+apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata:
   name: xdatabases.custom-api.example.org
@@ -650,7 +650,7 @@ View the conditions of a XRD under their `Status` with
 ```yaml {copy-lines="none"}
 kubectl describe xrd
 Name:         xpostgresqlinstances.database.starter.org
-API Version:  apiextensions.crossplane.io/v1
+API Version:  apiextensions.crossplane.io/v2
 Kind:         CompositeResourceDefinition
 # Removed for brevity
 Status:

--- a/content/v2.2/composition/composite-resource-definitions.md
+++ b/content/v2.2/composition/composite-resource-definitions.md
@@ -130,9 +130,7 @@ The XRD
 {{<hover label="xrdName" line="9">}}plural{{</hover>}} name, `.` (dot character),
 {{<hover label="xrdName" line="6">}}group{{</hover>}}.
 
-For example, {{<hover label="xrdName"
-line="4">}}mydatabases.example.org{{</hover>}} matches the {{<hover
-label="xrdName" line="9">}}plural{{</hover>}} name
+For example, {{<hover label="xrdName" line="4">}}mydatabases.example.org{{</hover>}} matches the {{<hover label="xrdName" line="9">}}plural{{</hover>}} name
 {{<hover label="xrdName" line="9">}}mydatabases{{</hover>}}, `.`
 {{<hover label="xrdName" line="6">}}group{{</hover>}} name,
 {{<hover label="xrdName" line="6">}}example.org{{</hover>}}.

--- a/content/v2.2/composition/composite-resources.md
+++ b/content/v2.2/composition/composite-resources.md
@@ -64,7 +64,7 @@ creates a custom API endpoint
 {{<hover label="xrd1" line="4">}}mydatabases.example.org{{</hover>}}.
 
 ```yaml {label="xrd1",copy-lines="none"}
-apiVersion: apiextensions.crossplane.io/v1
+apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata: 
   name: mydatabases.example.org

--- a/content/v2.2/composition/composition-revisions.md
+++ b/content/v2.2/composition/composition-revisions.md
@@ -169,7 +169,7 @@ spec:
 
 Apply the example XRD.
 ```yaml
-apiVersion: apiextensions.crossplane.io/v1
+apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata:
   name: myvpcs.aws.example.upbound.io

--- a/content/v2.2/guides/function-patch-and-transform.md
+++ b/content/v2.2/guides/function-patch-and-transform.md
@@ -533,7 +533,7 @@ spec:
 
 {{<expand "Reference CompositeResourceDefinition" >}}
 ```yaml {copy-lines="all"}
-apiVersion: apiextensions.crossplane.io/v1
+apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata:
   name: examples.example.org


### PR DESCRIPTION
In Crossplane v2, CompositeResourceDefinition (XRD) apiVersion v1 is deprecated. Update v2.0, v2.1, v2.2 and master doc content to show apiextensions.crossplane.io/v2 for all XRD YAML examples and kubectl describe output. Leaves migration/upgrade doc v1 examples unchanged.

Fixes #1037

<!--
Thanks for contributing to the docs! 

For information about local previews with Hugo read the contributing getting started guide:
https://docs.crossplane.io/contribute/contribute/

For information about Hugo's features like tabs and hint boxes read the styling features guide:
https://docs.crossplane.io/contribute/features/

For information on using Vale and testing locally read our Using Vale guide:
https://docs.crossplane.io/contribute/vale/

Need more help? Join the Crossplane Slack and ask in the #documentation channel.
https://slack.crossplane.io/
-->