### PR TITLE
docs: document required schemas and capability advertisement for composition functions

### DIFF
--- a/content/master/composition/compositions.md
+++ b/content/master/composition/compositions.md
@@ -616,6 +616,13 @@ things in the RunFunctionRequest.
 1. The function's __input__.
 1. The function pipeline's __context__.
 
+Crossplane also populates __meta.capabilities__ in the request with the set of
+protocol features it supports (for example, required resources, credentials,
+conditions, required schemas). Functions can check for a capability before
+relying on the corresponding feature and fall back gracefully when running with
+an older Crossplane that doesn't support it. See
+[Capability advertisement](#capability-advertisement) below.
+
 A function's main job is to update the __desired state__ and return it to
 Crossplane. It does this by returning a RunFunctionResponse.
 
@@ -960,6 +967,103 @@ Functions can request resources by:
 Crossplane limits dynamic resource requests to 5 iterations to prevent infinite
 loops. The function signals completion by returning the same resource requirements
 two iterations in a row.
+
+### Required schemas
+
+{{<hint "note">}}
+Required schemas are supported in Crossplane v2.2 and later. Functions can check
+for the `CAPABILITY_REQUIRED_SCHEMAS` capability before using this feature.
+{{</hint>}}
+
+Composition functions sometimes need OpenAPI schemas for resource kinds—for
+example to validate resources, generate resources with correct field types, or
+build schema-aware tooling. Per the [function specification](https://github.com/crossplane/crossplane/blob/main/contributing/specifications/functions.md),
+functions cannot assume network access, so they cannot fetch schemas from the
+API server directly.
+
+Crossplane extends the same pattern used for [required resources](#required-resources)
+to support schema requests:
+
+1. The function returns `requirements.schemas` in its RunFunctionResponse,
+   specifying the API version and kind of each schema it needs (for example,
+   `apps/v1`, `Deployment`).
+2. Crossplane fetches the OpenAPI schema from the cluster and calls the function
+   again with `required_schemas` populated on the RunFunctionRequest.
+3. If a schema is not found (for example, the GVK does not exist), Crossplane
+   sets that map entry to an empty `Schema` message so the function can
+   distinguish "Crossplane tried but found nothing" from "not processed yet."
+
+You can provide required schemas in the Composition pipeline step (bootstrap)
+or request them dynamically in the function response. Bootstrap is more
+efficient.
+
+**Bootstrap required schemas in the Composition:**
+
+```yaml
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: example-with-schemas
+spec:
+  compositeTypeRef:
+    apiVersion: example.crossplane.io/v1
+    kind: App
+  mode: Pipeline
+  pipeline:
+  - step: validate-and-compose
+    functionRef:
+      name: my-function
+    requirements:
+      requiredSchemas:
+      - requirementName: deployment-schema
+        apiVersion: apps/v1
+        kind: Deployment
+```
+
+The function receives the schema in `req.required_schemas["deployment-schema"]`
+and can use it for validation or code generation. The map key is the
+`requirementName` you specify in the Composition or in the function's
+`requirements.schemas` response.
+
+### Capability advertisement
+
+Crossplane populates `RequestMeta.capabilities` with all protocol features it
+supports when calling a function. When a function uses a feature (for example,
+required schemas or conditions) with an older Crossplane that doesn't support
+it, Crossplane silently ignores the unknown fields. The function has no way to
+know whether its request was honored.
+
+Capability advertisement fixes this: Crossplane sends the list of supported
+capabilities in every RunFunctionRequest. Functions should check for a
+capability before relying on the corresponding feature and fall back when it
+is absent.
+
+| Capability | Meaning |
+|------------|--------|
+| `CAPABILITY_CAPABILITIES` | Crossplane advertises capabilities; if another capability is absent, Crossplane doesn't support it. |
+| `CAPABILITY_REQUIRED_RESOURCES` | Crossplane supports `requirements.resources` and populates `required_resources`. |
+| `CAPABILITY_CREDENTIALS` | Crossplane supports credentials from the Composition. |
+| `CAPABILITY_CONDITIONS` | Crossplane supports status conditions in the function response. |
+| `CAPABILITY_REQUIRED_SCHEMAS` | Crossplane supports `requirements.schemas` and populates `required_schemas`. |
+
+Example (Python): check for a capability before using the feature:
+
+```python
+from crossplane.function import request, response
+
+if request.has_capability(req, fnv1.CAPABILITY_REQUIRED_SCHEMAS):
+    response.require_schema(rsp, "xr", "example.org/v1", "MyXR")
+    schema = request.get_required_schema(req, "xr")
+    if schema:
+        # Use schema for validation or code generation
+        pass
+else:
+    # Crossplane doesn't support required schemas; skip or use a fallback
+    pass
+```
+
+Function SDKs provide helpers such as `has_capability` and `get_required_schema`;
+see your SDK documentation for the exact API.
 
 ### Function pipeline context
 

--- a/content/master/composition/compositions.md
+++ b/content/master/composition/compositions.md
@@ -616,11 +616,11 @@ things in the RunFunctionRequest.
 1. The function's __input__.
 1. The function pipeline's __context__.
 
-Crossplane also populates __meta.capabilities__ in the request with the set of
+Crossplane also populates `meta.capabilities` in the request with the set of
 protocol features it supports (for example, required resources, credentials,
-conditions, required schemas). Functions can check for a capability before
-relying on the corresponding feature and fall back gracefully when running with
-an older Crossplane that doesn't support it. See
+conditions, required schemas). Functions can test for a capability before
+relying on the corresponding feature and fall back when running with an older
+Crossplane that doesn't support it. See
 [Capability advertisement](#capability-advertisement) below.
 
 A function's main job is to update the __desired state__ and return it to
@@ -971,14 +971,15 @@ two iterations in a row.
 ### Required schemas
 
 {{<hint "note">}}
-Required schemas are supported in Crossplane v2.2 and later. Functions can check
-for the `CAPABILITY_REQUIRED_SCHEMAS` capability before using this feature.
+Crossplane v2.2 and later support required schemas. Functions can test for the
+`CAPABILITY_REQUIRED_SCHEMAS` capability before using this feature.
 {{</hint>}}
 
-Composition functions sometimes need OpenAPI schemas for resource kinds—for
+Composition functions sometimes need OpenAPI schemas for resource kinds, for
 example to validate resources, generate resources with correct field types, or
-build schema-aware tooling. Per the [function specification](https://github.com/crossplane/crossplane/blob/main/contributing/specifications/functions.md),
-functions cannot assume network access, so they cannot fetch schemas from the
+build tooling that uses schemas. Per the
+[function specification](https://github.com/crossplane/crossplane/blob/main/contributing/specifications/functions.md),
+functions can't assume network access, so they can't fetch schemas from the
 API server directly.
 
 Crossplane extends the same pattern used for [required resources](#required-resources)
@@ -989,7 +990,7 @@ to support schema requests:
    `apps/v1`, `Deployment`).
 2. Crossplane fetches the OpenAPI schema from the cluster and calls the function
    again with `required_schemas` populated on the RunFunctionRequest.
-3. If a schema is not found (for example, the GVK does not exist), Crossplane
+3. If a schema isn't found (for example, the kind doesn't exist), Crossplane
    sets that map entry to an empty `Schema` message so the function can
    distinguish "Crossplane tried but found nothing" from "not processed yet."
 
@@ -1027,14 +1028,22 @@ and can use it for validation or code generation. The map key is the
 
 ### Capability advertisement
 
+{{<hint "note">}}
+Crossplane versions older than v2.2 don't advertise capabilities. When
+`meta.capabilities` is empty, the function can't tell which features Crossplane
+supports. Function SDKs provide a helper (`advertises_capabilities`
+in Python, `AdvertisesCapabilities` in Go) to detect this case so functions
+can pick a fallback strategy.
+{{</hint>}}
+
 Crossplane populates `RequestMeta.capabilities` with all protocol features it
 supports when calling a function. When a function uses a feature (for example,
 required schemas or conditions) with an older Crossplane that doesn't support
-it, Crossplane silently ignores the unknown fields. The function has no way to
-know whether its request was honored.
+it, Crossplane ignores the unknown fields. The function has no way to know
+whether Crossplane honored its request.
 
-Capability advertisement fixes this: Crossplane sends the list of supported
-capabilities in every RunFunctionRequest. Functions should check for a
+Capability advertisement fixes this problem. Crossplane sends the list of
+supported capabilities in every RunFunctionRequest. Functions should test for a
 capability before relying on the corresponding feature and fall back when it
 is absent.
 
@@ -1046,9 +1055,10 @@ is absent.
 | `CAPABILITY_CONDITIONS` | Crossplane supports status conditions in the function response. |
 | `CAPABILITY_REQUIRED_SCHEMAS` | Crossplane supports `requirements.schemas` and populates `required_schemas`. |
 
-Example (Python): check for a capability before using the feature:
+This Python example tests for a capability before using the feature:
 
 ```python
+import crossplane.function.proto.v1.run_function_pb2 as fnv1
 from crossplane.function import request, response
 
 if request.has_capability(req, fnv1.CAPABILITY_REQUIRED_SCHEMAS):

--- a/content/v2.2/composition/compositions.md
+++ b/content/v2.2/composition/compositions.md
@@ -599,6 +599,13 @@ things in the RunFunctionRequest.
 1. The function's __input__.
 1. The function pipeline's __context__.
 
+Crossplane also populates __meta.capabilities__ in the request with the set of
+protocol features it supports (for example, required resources, credentials,
+conditions, required schemas). Functions can check for a capability before
+relying on the corresponding feature and fall back gracefully when running with
+an older Crossplane that doesn't support it. See
+[Capability advertisement](#capability-advertisement) below.
+
 A function's main job is to update the __desired state__ and return it to
 Crossplane. It does this by returning a RunFunctionResponse.
 
@@ -943,6 +950,103 @@ Functions can request resources by:
 Crossplane limits dynamic resource requests to 5 iterations to prevent infinite
 loops. The function signals completion by returning the same resource requirements
 two iterations in a row.
+
+### Required schemas
+
+{{<hint "note">}}
+Required schemas are supported in Crossplane v2.2 and later. Functions can check
+for the `CAPABILITY_REQUIRED_SCHEMAS` capability before using this feature.
+{{</hint>}}
+
+Composition functions sometimes need OpenAPI schemas for resource kinds—for
+example to validate resources, generate resources with correct field types, or
+build schema-aware tooling. Per the [function specification](https://github.com/crossplane/crossplane/blob/main/contributing/specifications/functions.md),
+functions cannot assume network access, so they cannot fetch schemas from the
+API server directly.
+
+Crossplane extends the same pattern used for [required resources](#required-resources)
+to support schema requests:
+
+1. The function returns `requirements.schemas` in its RunFunctionResponse,
+   specifying the API version and kind of each schema it needs (for example,
+   `apps/v1`, `Deployment`).
+2. Crossplane fetches the OpenAPI schema from the cluster and calls the function
+   again with `required_schemas` populated on the RunFunctionRequest.
+3. If a schema is not found (for example, the GVK does not exist), Crossplane
+   sets that map entry to an empty `Schema` message so the function can
+   distinguish "Crossplane tried but found nothing" from "not processed yet."
+
+You can provide required schemas in the Composition pipeline step (bootstrap)
+or request them dynamically in the function response. Bootstrap is more
+efficient.
+
+**Bootstrap required schemas in the Composition:**
+
+```yaml
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: example-with-schemas
+spec:
+  compositeTypeRef:
+    apiVersion: example.crossplane.io/v1
+    kind: App
+  mode: Pipeline
+  pipeline:
+  - step: validate-and-compose
+    functionRef:
+      name: my-function
+    requirements:
+      requiredSchemas:
+      - requirementName: deployment-schema
+        apiVersion: apps/v1
+        kind: Deployment
+```
+
+The function receives the schema in `req.required_schemas["deployment-schema"]`
+and can use it for validation or code generation. The map key is the
+`requirementName` you specify in the Composition or in the function's
+`requirements.schemas` response.
+
+### Capability advertisement
+
+Crossplane populates `RequestMeta.capabilities` with all protocol features it
+supports when calling a function. When a function uses a feature (for example,
+required schemas or conditions) with an older Crossplane that doesn't support
+it, Crossplane silently ignores the unknown fields. The function has no way to
+know whether its request was honored.
+
+Capability advertisement fixes this: Crossplane sends the list of supported
+capabilities in every RunFunctionRequest. Functions should check for a
+capability before relying on the corresponding feature and fall back when it
+is absent.
+
+| Capability | Meaning |
+|------------|--------|
+| `CAPABILITY_CAPABILITIES` | Crossplane advertises capabilities; if another capability is absent, Crossplane doesn't support it. |
+| `CAPABILITY_REQUIRED_RESOURCES` | Crossplane supports `requirements.resources` and populates `required_resources`. |
+| `CAPABILITY_CREDENTIALS` | Crossplane supports credentials from the Composition. |
+| `CAPABILITY_CONDITIONS` | Crossplane supports status conditions in the function response. |
+| `CAPABILITY_REQUIRED_SCHEMAS` | Crossplane supports `requirements.schemas` and populates `required_schemas`. |
+
+Example (Python): check for a capability before using the feature:
+
+```python
+from crossplane.function import request, response
+
+if request.has_capability(req, fnv1.CAPABILITY_REQUIRED_SCHEMAS):
+    response.require_schema(rsp, "xr", "example.org/v1", "MyXR")
+    schema = request.get_required_schema(req, "xr")
+    if schema:
+        # Use schema for validation or code generation
+        pass
+else:
+    # Crossplane doesn't support required schemas; skip or use a fallback
+    pass
+```
+
+Function SDKs provide helpers such as `has_capability` and `get_required_schema`;
+see your SDK documentation for the exact API.
 
 ### Function pipeline context
 

--- a/content/v2.2/composition/compositions.md
+++ b/content/v2.2/composition/compositions.md
@@ -599,11 +599,11 @@ things in the RunFunctionRequest.
 1. The function's __input__.
 1. The function pipeline's __context__.
 
-Crossplane also populates __meta.capabilities__ in the request with the set of
+Crossplane also populates `meta.capabilities` in the request with the set of
 protocol features it supports (for example, required resources, credentials,
-conditions, required schemas). Functions can check for a capability before
-relying on the corresponding feature and fall back gracefully when running with
-an older Crossplane that doesn't support it. See
+conditions, required schemas). Functions can test for a capability before
+relying on the corresponding feature and fall back when running with an older
+Crossplane that doesn't support it. See
 [Capability advertisement](#capability-advertisement) below.
 
 A function's main job is to update the __desired state__ and return it to
@@ -954,14 +954,15 @@ two iterations in a row.
 ### Required schemas
 
 {{<hint "note">}}
-Required schemas are supported in Crossplane v2.2 and later. Functions can check
-for the `CAPABILITY_REQUIRED_SCHEMAS` capability before using this feature.
+Crossplane v2.2 and later support required schemas. Functions can test for the
+`CAPABILITY_REQUIRED_SCHEMAS` capability before using this feature.
 {{</hint>}}
 
-Composition functions sometimes need OpenAPI schemas for resource kinds—for
+Composition functions sometimes need OpenAPI schemas for resource kinds, for
 example to validate resources, generate resources with correct field types, or
-build schema-aware tooling. Per the [function specification](https://github.com/crossplane/crossplane/blob/main/contributing/specifications/functions.md),
-functions cannot assume network access, so they cannot fetch schemas from the
+build tooling that uses schemas. Per the
+[function specification](https://github.com/crossplane/crossplane/blob/main/contributing/specifications/functions.md),
+functions can't assume network access, so they can't fetch schemas from the
 API server directly.
 
 Crossplane extends the same pattern used for [required resources](#required-resources)
@@ -972,7 +973,7 @@ to support schema requests:
    `apps/v1`, `Deployment`).
 2. Crossplane fetches the OpenAPI schema from the cluster and calls the function
    again with `required_schemas` populated on the RunFunctionRequest.
-3. If a schema is not found (for example, the GVK does not exist), Crossplane
+3. If a schema isn't found (for example, the kind doesn't exist), Crossplane
    sets that map entry to an empty `Schema` message so the function can
    distinguish "Crossplane tried but found nothing" from "not processed yet."
 
@@ -1010,14 +1011,22 @@ and can use it for validation or code generation. The map key is the
 
 ### Capability advertisement
 
+{{<hint "note">}}
+Crossplane versions older than v2.2 don't advertise capabilities. When
+`meta.capabilities` is empty, the function can't tell which features Crossplane
+supports. Function SDKs provide a helper (`advertises_capabilities`
+in Python, `AdvertisesCapabilities` in Go) to detect this case so functions
+can pick a fallback strategy.
+{{</hint>}}
+
 Crossplane populates `RequestMeta.capabilities` with all protocol features it
 supports when calling a function. When a function uses a feature (for example,
 required schemas or conditions) with an older Crossplane that doesn't support
-it, Crossplane silently ignores the unknown fields. The function has no way to
-know whether its request was honored.
+it, Crossplane ignores the unknown fields. The function has no way to know
+whether Crossplane honored its request.
 
-Capability advertisement fixes this: Crossplane sends the list of supported
-capabilities in every RunFunctionRequest. Functions should check for a
+Capability advertisement fixes this problem. Crossplane sends the list of
+supported capabilities in every RunFunctionRequest. Functions should test for a
 capability before relying on the corresponding feature and fall back when it
 is absent.
 
@@ -1029,9 +1038,10 @@ is absent.
 | `CAPABILITY_CONDITIONS` | Crossplane supports status conditions in the function response. |
 | `CAPABILITY_REQUIRED_SCHEMAS` | Crossplane supports `requirements.schemas` and populates `required_schemas`. |
 
-Example (Python): check for a capability before using the feature:
+This Python example tests for a capability before using the feature:
 
 ```python
+import crossplane.function.proto.v1.run_function_pb2 as fnv1
 from crossplane.function import request, response
 
 if request.has_capability(req, fnv1.CAPABILITY_REQUIRED_SCHEMAS):

--- a/content/v2.3/composition/compositions.md
+++ b/content/v2.3/composition/compositions.md
@@ -616,6 +616,13 @@ things in the RunFunctionRequest.
 1. The function's __input__.
 1. The function pipeline's __context__.
 
+Crossplane also populates `meta.capabilities` in the request with the set of
+protocol features it supports (for example, required resources, credentials,
+conditions, required schemas). Functions can test for a capability before
+relying on the corresponding feature and fall back when running with an older
+Crossplane that doesn't support it. See
+[Capability advertisement](#capability-advertisement) below.
+
 A function's main job is to update the __desired state__ and return it to
 Crossplane. It does this by returning a RunFunctionResponse.
 
@@ -960,6 +967,113 @@ Functions can request resources by:
 Crossplane limits dynamic resource requests to 5 iterations to prevent infinite
 loops. The function signals completion by returning the same resource requirements
 two iterations in a row.
+
+### Required schemas
+
+{{<hint "note">}}
+Crossplane v2.2 and later support required schemas. Functions can test for the
+`CAPABILITY_REQUIRED_SCHEMAS` capability before using this feature.
+{{</hint>}}
+
+Composition functions sometimes need OpenAPI schemas for resource kinds, for
+example to validate resources, generate resources with correct field types, or
+build tooling that uses schemas. Per the
+[function specification](https://github.com/crossplane/crossplane/blob/main/contributing/specifications/functions.md),
+functions can't assume network access, so they can't fetch schemas from the
+API server directly.
+
+Crossplane extends the same pattern used for [required resources](#required-resources)
+to support schema requests:
+
+1. The function returns `requirements.schemas` in its RunFunctionResponse,
+   specifying the API version and kind of each schema it needs (for example,
+   `apps/v1`, `Deployment`).
+2. Crossplane fetches the OpenAPI schema from the cluster and calls the function
+   again with `required_schemas` populated on the RunFunctionRequest.
+3. If a schema isn't found (for example, the kind doesn't exist), Crossplane
+   sets that map entry to an empty `Schema` message so the function can
+   distinguish "Crossplane tried but found nothing" from "not processed yet."
+
+You can provide required schemas in the Composition pipeline step (bootstrap)
+or request them dynamically in the function response. Bootstrap is more
+efficient.
+
+**Bootstrap required schemas in the Composition:**
+
+```yaml
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: example-with-schemas
+spec:
+  compositeTypeRef:
+    apiVersion: example.crossplane.io/v1
+    kind: App
+  mode: Pipeline
+  pipeline:
+  - step: validate-and-compose
+    functionRef:
+      name: my-function
+    requirements:
+      requiredSchemas:
+      - requirementName: deployment-schema
+        apiVersion: apps/v1
+        kind: Deployment
+```
+
+The function receives the schema in `req.required_schemas["deployment-schema"]`
+and can use it for validation or code generation. The map key is the
+`requirementName` you specify in the Composition or in the function's
+`requirements.schemas` response.
+
+### Capability advertisement
+
+{{<hint "note">}}
+Crossplane versions older than v2.2 don't advertise capabilities. When
+`meta.capabilities` is empty, the function can't tell which features Crossplane
+supports. Function SDKs provide a helper (`advertises_capabilities`
+in Python, `AdvertisesCapabilities` in Go) to detect this case so functions
+can pick a fallback strategy.
+{{</hint>}}
+
+Crossplane populates `RequestMeta.capabilities` with all protocol features it
+supports when calling a function. When a function uses a feature (for example,
+required schemas or conditions) with an older Crossplane that doesn't support
+it, Crossplane ignores the unknown fields. The function has no way to know
+whether Crossplane honored its request.
+
+Capability advertisement fixes this problem. Crossplane sends the list of
+supported capabilities in every RunFunctionRequest. Functions should test for a
+capability before relying on the corresponding feature and fall back when it
+is absent.
+
+| Capability | Meaning |
+|------------|--------|
+| `CAPABILITY_CAPABILITIES` | Crossplane advertises capabilities; if another capability is absent, Crossplane doesn't support it. |
+| `CAPABILITY_REQUIRED_RESOURCES` | Crossplane supports `requirements.resources` and populates `required_resources`. |
+| `CAPABILITY_CREDENTIALS` | Crossplane supports credentials from the Composition. |
+| `CAPABILITY_CONDITIONS` | Crossplane supports status conditions in the function response. |
+| `CAPABILITY_REQUIRED_SCHEMAS` | Crossplane supports `requirements.schemas` and populates `required_schemas`. |
+
+This Python example tests for a capability before using the feature:
+
+```python
+import crossplane.function.proto.v1.run_function_pb2 as fnv1
+from crossplane.function import request, response
+
+if request.has_capability(req, fnv1.CAPABILITY_REQUIRED_SCHEMAS):
+    response.require_schema(rsp, "xr", "example.org/v1", "MyXR")
+    schema = request.get_required_schema(req, "xr")
+    if schema:
+        # Use schema for validation or code generation
+        pass
+else:
+    # Crossplane doesn't support required schemas; skip or use a fallback
+    pass
+```
+
+Function SDKs provide helpers such as `has_capability` and `get_required_schema`;
+see your SDK documentation for the exact API.
 
 ### Function pipeline context
 


### PR DESCRIPTION
## What

- **Required schemas (Fixes #1040):** New section explaining how composition functions can request OpenAPI schemas via `requirements.schemas`; Crossplane populates `required_schemas` on the next request. Covers bootstrap (Composition) and dynamic requests, with a YAML example.
- **Capability advertisement (Fixes #1041):** New section explaining `RequestMeta.capabilities`—Crossplane lists supported protocol features so functions can check before using a feature and fall back on older controllers. Includes capability table and Python example.
- **Intro:** Brief mention of `meta.capabilities` in "How composition functions work" with a link to the new section.

## Why

Content requested in #1040 and #1041; implementation is in crossplane/crossplane#7022 (v2.2). Matches existing style (e.g. Required resources section).