### PR TITLE
Add speciesism-aware language rules to Vale config

### DIFF
--- a/utils/vale/.vale.ini
+++ b/utils/vale/.vale.ini
@@ -1,7 +1,7 @@
 StylesPath = styles
 
 [*.md]
-BasedOnStyles = alex, Google, Microsoft, proselint, write-good, Crossplane, Vale, gitlab
+BasedOnStyles = alex, Google, Microsoft, proselint, write-good, Crossplane, Vale, gitlab, Speciesism
 
 # Disable Vale's spelling to allow for the use of our custom dictionary in styles/Crossplane/Spelling.yml
 Vale.Spelling = NO

--- a/utils/vale/styles/Speciesism/AnimalIdioms.yml
+++ b/utils/vale/styles/Speciesism/AnimalIdioms.yml
@@ -1,0 +1,32 @@
+extends: substitution
+message: "Consider using '%s' instead of '%s'. This phrase normalizes violence toward animals."
+link: https://doi.org/10.1007/s43681-023-00380-w
+level: warning
+ignorecase: true
+swap:
+  'kill two birds with one stone': accomplish two things at once
+  'killing two birds with one stone': accomplishing two things at once
+  'killed two birds with one stone': accomplished two things at once
+  'beat a dead horse': belabor the point
+  'beating a dead horse': belaboring the point
+  'flog a dead horse': belabor the point
+  'flogging a dead horse': belaboring the point
+  'bring home the bacon': bring home the results
+  'bringing home the bacon': bringing home the results
+  'brought home the bacon': brought home the results
+  'more than one way to skin a cat': more than one way to solve this
+  'many ways to skin a cat': many ways to approach this
+  'let the cat out of the bag': reveal the secret
+  'letting the cat out of the bag': revealing the secret
+  'open a can of worms': create a complicated situation
+  'opening a can of worms': creating a complicated situation
+  'opened a can of worms': created a complicated situation
+  'wild goose chase': pointless pursuit
+  'take the bull by the horns': face the challenge head-on
+  'taking the bull by the horns': facing the challenge head-on
+  'took the bull by the horns': faced the challenge head-on
+  'like shooting fish in a barrel': extremely easy
+  'straight from the horse''s mouth': directly from the source
+  'from the horse''s mouth': from a reliable source
+  'whack-a-mole': recurring problem
+  'whack a mole': recurring problem

--- a/utils/vale/styles/Speciesism/AnimalMetaphors.yml
+++ b/utils/vale/styles/Speciesism/AnimalMetaphors.yml
@@ -1,0 +1,14 @@
+extends: substitution
+message: "Consider using '%s' instead of '%s'. This term references animals as objects or tools."
+link: https://doi.org/10.1007/s43681-023-00380-w
+level: warning
+ignorecase: true
+swap:
+  'guinea pig': test subject
+  'sacred cow': unquestioned belief
+  'sacred cows': unquestioned beliefs
+  'scapegoat(?:ed|ing)?': wrongly blamed
+  'dog-eat-dog': ruthlessly competitive
+  'dog eat dog': ruthlessly competitive
+  'rat race': competitive grind
+  'red herring': false lead

--- a/utils/vale/styles/Speciesism/TechTerminology.yml
+++ b/utils/vale/styles/Speciesism/TechTerminology.yml
@@ -1,0 +1,13 @@
+extends: substitution
+message: "Consider using '%s' instead of '%s'. This technical term has a more precise alternative."
+level: suggestion
+ignorecase: true
+swap:
+  'canary deployment': progressive rollout
+  'canary release': progressive rollout
+  'canary test(?:ing)?': incremental testing
+  'monkey[- ]?patch(?:ed|ing)?': runtime patch
+  'duck[- ]?typ(?:ed|ing)': structural typing
+  'dogfood(?:ing)?': self-hosting
+  'eat(?:ing)? (?:your|our|their) own dogfood': self-testing
+  'rubber duck(?:ing)? debugging': talk-through debugging


### PR DESCRIPTION
## Summary

This adds a set of Vale rules that flag common speciesist idioms and suggest neutral alternatives — similar to how [alex](https://github.com/get-alex/alex) catches gendered or ableist language, but focused on phrases that normalize violence toward animals.

The rules are organized into three files:
- **AnimalIdioms.yml** — Common phrases like "kill two birds with one stone" → "accomplish two things at once"
- **AnimalMetaphors.yml** — Terms like "guinea pig" → "test subject", "scapegoat" → "wrongly blamed"
- **TechTerminology.yml** — Tech jargon like "monkey-patch" → "runtime patch" (set to `suggestion` level only)

These are `warning`-level (or `suggestion` for tech terms) — they won't block CI, just surface alternatives during review.

## Why

An increasing number of open source documentation projects are adopting speciesism-aware linting alongside their existing inclusive language checks. Projects like webpack.js.org have recently added similar rules, recognizing that animal-derived idioms often normalize casual violence in ways that parallel other forms of exclusionary language.

Since Crossplane already lints for inclusive language with alex, Google, and gitlab styles, this is a natural extension of that commitment.

The rules reference [this peer-reviewed paper](https://doi.org/10.1007/s43681-023-00380-w) on how language normalizes violence toward animals.

## Changes

- Added `Speciesism/` style directory with three rule files under `utils/vale/styles/`
- Updated `utils/vale/.vale.ini` to include `Speciesism` in `BasedOnStyles`