### PR TITLE
docs: clarify writeConnectionSecretToRef removal is XR-only, not MR-level

### DIFF
--- a/content/master/guides/connection-details-composition.md
+++ b/content/master/guides/connection-details-composition.md
@@ -17,7 +17,9 @@ resources and exposes them for the XR.
 
 {{<hint "note">}}
 Crossplane v1 included a feature that automatically created connection details
-for XRs.
+for XRs. Crossplane v2 removes this feature **for XRs only**. Managed Resources (MRs)
+aren't affected by this change and still support connection details via their
+`writeConnectionSecretToRef` field.
 
 To learn more about how to specify XR connection details in Crossplane v1, please see the
 [v1 connection details]({{<ref "../../v1.20/concepts/connection-details">}}) docs page.

--- a/content/master/guides/upgrade-to-crossplane-v2.md
+++ b/content/master/guides/upgrade-to-crossplane-v2.md
@@ -96,6 +96,13 @@ or [External Secrets Operator](https://external-secrets.io/latest/) before upgra
 ### Composite resource connection details
 **Removed**: composite resources no longer have native connection details support.
 
+{{<hint "tip">}}
+**This only affects XRs, managed resources aren't affected.**
+
+Managed resources (MRs) still support the `writeConnectionSecretToRef` field on any
+MR spec.
+{{</hint>}}
+
 You can recreate this feature by composing your own connection details `Secret`
 as described in the [connection details composition guide]({{<ref "./connection-details-composition">}}).
 

--- a/content/master/whats-new/_index.md
+++ b/content/master/whats-new/_index.md
@@ -283,6 +283,7 @@ remained in alpha for over two years and are now unmaintained.
 Composite resources no longer have native connection details support. You
 can recreate this feature by composing your own connection details `Secret`
 as described in the [connection details composition guide]({{<ref "../guides/connection-details-composition">}}).
+Connection details for managed resources (MRs) aren't affected.
 
 Crossplane v2 drops the `--registry` flag that allowed users to specify a default
 registry value and now requires users to always specify a fully qualified URL when

--- a/content/v2.0/guides/connection-details-composition.md
+++ b/content/v2.0/guides/connection-details-composition.md
@@ -17,7 +17,9 @@ resources and exposes them for the XR.
 
 {{<hint "note">}}
 Crossplane v1 included a feature that automatically created connection details
-for XRs.
+for XRs. Crossplane v2 removes this feature **for XRs only**. Managed Resources (MRs)
+aren't affected by this change and still support connection details via their
+`writeConnectionSecretToRef` field.
 
 To learn more about how to specify XR connection details in Crossplane v1, please see the
 [v1 connection details]({{<ref "../../v1.20/concepts/connection-details">}}) docs page.

--- a/content/v2.0/guides/upgrade-to-crossplane-v2.md
+++ b/content/v2.0/guides/upgrade-to-crossplane-v2.md
@@ -96,6 +96,13 @@ or [External Secrets Operator](https://external-secrets.io/latest/) before upgra
 ### Composite resource connection details
 **Removed**: composite resources no longer have native connection details support.
 
+{{<hint "tip">}}
+**This only affects XRs, managed resources aren't affected.**
+
+Managed resources (MRs) still support the `writeConnectionSecretToRef` field on any
+MR spec.
+{{</hint>}}
+
 You can recreate this feature by composing your own connection details `Secret`
 as described in the [connection details composition guide]({{<ref "./connection-details-composition">}}).
 

--- a/content/v2.0/whats-new/_index.md
+++ b/content/v2.0/whats-new/_index.md
@@ -283,6 +283,7 @@ remained in alpha for over two years and are now unmaintained.
 Composite resources no longer have native connection details support. You
 can recreate this feature by composing your own connection details `Secret`
 as described in the [connection details composition guide]({{<ref "../guides/connection-details-composition">}}).
+Connection details for managed resources (MRs) aren't affected.
 
 Crossplane v2 drops the `--registry` flag that allowed users to specify a default
 registry value and now requires users to always specify a fully qualified URL when

--- a/content/v2.1/guides/connection-details-composition.md
+++ b/content/v2.1/guides/connection-details-composition.md
@@ -17,7 +17,9 @@ resources and exposes them for the XR.
 
 {{<hint "note">}}
 Crossplane v1 included a feature that automatically created connection details
-for XRs.
+for XRs. Crossplane v2 removes this feature **for XRs only**. Managed Resources (MRs)
+aren't affected by this change and still support connection details via their
+`writeConnectionSecretToRef` field.
 
 To learn more about how to specify XR connection details in Crossplane v1, please see the
 [v1 connection details]({{<ref "../../v1.20/concepts/connection-details">}}) docs page.

--- a/content/v2.1/guides/upgrade-to-crossplane-v2.md
+++ b/content/v2.1/guides/upgrade-to-crossplane-v2.md
@@ -96,6 +96,13 @@ or [External Secrets Operator](https://external-secrets.io/latest/) before upgra
 ### Composite resource connection details
 **Removed**: composite resources no longer have native connection details support.
 
+{{<hint "tip">}}
+**This only affects XRs, managed resources aren't affected.**
+
+Managed resources (MRs) still support the `writeConnectionSecretToRef` field on any
+MR spec.
+{{</hint>}}
+
 You can recreate this feature by composing your own connection details `Secret`
 as described in the [connection details composition guide]({{<ref "./connection-details-composition">}}).
 

--- a/content/v2.1/whats-new/_index.md
+++ b/content/v2.1/whats-new/_index.md
@@ -283,6 +283,7 @@ remained in alpha for over two years and are now unmaintained.
 Composite resources no longer have native connection details support. You
 can recreate this feature by composing your own connection details `Secret`
 as described in the [connection details composition guide]({{<ref "../guides/connection-details-composition">}}).
+Connection details for managed resources (MRs) aren't affected.
 
 Crossplane v2 drops the `--registry` flag that allowed users to specify a default
 registry value and now requires users to always specify a fully qualified URL when

--- a/content/v2.2/guides/connection-details-composition.md
+++ b/content/v2.2/guides/connection-details-composition.md
@@ -17,7 +17,9 @@ resources and exposes them for the XR.
 
 {{<hint "note">}}
 Crossplane v1 included a feature that automatically created connection details
-for XRs.
+for XRs. Crossplane v2 removes this feature **for XRs only**. Managed Resources (MRs)
+aren't affected by this change and still support connection details via their
+`writeConnectionSecretToRef` field.
 
 To learn more about how to specify XR connection details in Crossplane v1, please see the
 [v1 connection details]({{<ref "../../v1.20/concepts/connection-details">}}) docs page.

--- a/content/v2.2/guides/upgrade-to-crossplane-v2.md
+++ b/content/v2.2/guides/upgrade-to-crossplane-v2.md
@@ -96,6 +96,13 @@ or [External Secrets Operator](https://external-secrets.io/latest/) before upgra
 ### Composite resource connection details
 **Removed**: composite resources no longer have native connection details support.
 
+{{<hint "tip">}}
+**This only affects XRs, managed resources aren't affected.**
+
+Managed resources (MRs) still support the `writeConnectionSecretToRef` field on any
+MR spec.
+{{</hint>}}
+
 You can recreate this feature by composing your own connection details `Secret`
 as described in the [connection details composition guide]({{<ref "./connection-details-composition">}}).
 

--- a/content/v2.2/whats-new/_index.md
+++ b/content/v2.2/whats-new/_index.md
@@ -283,6 +283,7 @@ remained in alpha for over two years and are now unmaintained.
 Composite resources no longer have native connection details support. You
 can recreate this feature by composing your own connection details `Secret`
 as described in the [connection details composition guide]({{<ref "../guides/connection-details-composition">}}).
+Connection details for managed resources (MRs) aren't affected.
 
 Crossplane v2 drops the `--registry` flag that allowed users to specify a default
 registry value and now requires users to always specify a fully qualified URL when


### PR DESCRIPTION
A common source of confusion when upgrading to v2 is assuming that the removal of native XR connection details also affects managed resources. This is not the case — writeConnectionSecretToRef on MRs is unchanged.

Add a tip callout to the upgrade guide's "Composite resource connection details" section and expand the note in the connection details composition guide to explicitly state that only the XR-level aggregation was removed, while MR-level usage continues to work as before. Applied across all v2.x versions and master.

<!--
Thanks for contributing to the docs! 

For information about local previews with Hugo read the contributing getting started guide:
https://docs.crossplane.io/contribute/contribute/

For information about Hugo's features like tabs and hint boxes read the styling features guide:
https://docs.crossplane.io/contribute/features/

For information on using Vale and testing locally read our Using Vale guide:
https://docs.crossplane.io/contribute/vale/

Need more help? Join the Crossplane Slack and ask in the #documentation channel.
https://slack.crossplane.io/
-->