### PR TITLE
docs: add configuration instructions for provider authentication with Workload Identity

### DIFF
--- a/content/master/guides/crossplane-with-workload-identity.md
+++ b/content/master/guides/crossplane-with-workload-identity.md
@@ -697,9 +697,30 @@ metadata:
   namespace: crossplane-system
 ```
 
+### Configure provider authentication with Workload Identity
+
+By default, each provider creates its own ServiceAccount with a random name. To use Workload Identity for providers, create a `DeploymentRuntimeConfig` to assign a specific ServiceAccount.
+
+Create a `DeploymentRuntimeConfig` to force providers to use this ServiceAccount:
+
+```shell
+cat <<EOF | kubectl apply -f -
+apiVersion: pkg.crossplane.io/v1beta1
+kind: DeploymentRuntimeConfig
+metadata:
+  name: gcp-runtime-config
+spec:
+  deploymentTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: crossplane
+EOF
+```
+
 ### Test package installation from artifact registry
 
-Once configured, you can install Crossplane packages (Providers, Functions, Configurations) from your Artifact Registry. Here's an example using a Provider:
+Once configured, you can install Crossplane packages (Providers, Functions, Configurations) from your Artifact Registry. Reference the `DeploymentRuntimeConfig` in the Provider:
 
 ```shell
 kubectl apply -f - <<EOF
@@ -709,6 +730,8 @@ metadata:
   name: provider-gcp-storage
 spec:
   package: us-docker.pkg.dev/${PROJECT_ID}/crossplane/provider-gcp-storage:v1.2.0
+  runtimeConfigRef:
+    name: gcp-runtime-config
 EOF
 ```
 


### PR DESCRIPTION
We had trouble setting up WIF with the current documentation, so I am updating the documentation accordingly.

<!--
Thanks for contributing to the docs! 

For information about local previews with Hugo read the contributing getting started guide:
https://docs.crossplane.io/contribute/contribute/

For information about Hugo's features like tabs and hint boxes read the styling features guide:
https://docs.crossplane.io/contribute/features/

For information on using Vale and testing locally read our Using Vale guide:
https://docs.crossplane.io/contribute/vale/

Need more help? Join the Crossplane Slack and ask in the #documentation channel.
https://slack.crossplane.io/
-->