### PR TITLE
docs: argocd healthcheck - mark packages Degraded when Installed=False

### DIFF
--- a/content/master/guides/crossplane-with-argo-cd.md
+++ b/content/master/guides/crossplane-with-argo-cd.md
@@ -174,6 +174,14 @@ data:
             end
           end
 
+          if condition.type == "Installed" then
+            if condition.status == "False" then
+              health_status.status = "Degraded"
+              health_status.message = condition.message
+              return health_status
+            end
+          end
+
           if contains({"Ready", "Healthy", "Offered", "Established", "ValidPipeline", "RevisionHealthy"}, condition.type) then
             if condition.status == "True" then
               health_status.status = "Healthy"

--- a/content/v1.20/guides/crossplane-with-argo-cd.md
+++ b/content/v1.20/guides/crossplane-with-argo-cd.md
@@ -168,6 +168,14 @@ data:
             end
           end
 
+          if condition.type == "Installed" then
+            if condition.status == "False" then
+              health_status.status = "Degraded"
+              health_status.message = condition.message
+              return health_status
+            end
+          end
+
           if contains({"Ready", "Healthy", "Offered", "Established"}, condition.type) then
             if condition.status == "True" then
               health_status.status = "Healthy"

--- a/content/v2.0-preview/guides/crossplane-with-argo-cd.md
+++ b/content/v2.0-preview/guides/crossplane-with-argo-cd.md
@@ -167,6 +167,14 @@ data:
             end
           end
 
+          if condition.type == "Installed" then
+            if condition.status == "False" then
+              health_status.status = "Degraded"
+              health_status.message = condition.message
+              return health_status
+            end
+          end
+
           if contains({"Ready", "Healthy", "Offered", "Established"}, condition.type) then
             if condition.status == "True" then
               health_status.status = "Healthy"

--- a/content/v2.0/guides/crossplane-with-argo-cd.md
+++ b/content/v2.0/guides/crossplane-with-argo-cd.md
@@ -174,6 +174,14 @@ data:
             end
           end
 
+          if condition.type == "Installed" then
+            if condition.status == "False" then
+              health_status.status = "Degraded"
+              health_status.message = condition.message
+              return health_status
+            end
+          end
+
           if contains({"Ready", "Healthy", "Offered", "Established", "ValidPipeline", "RevisionHealthy"}, condition.type) then
             if condition.status == "True" then
               health_status.status = "Healthy"

--- a/content/v2.1/guides/crossplane-with-argo-cd.md
+++ b/content/v2.1/guides/crossplane-with-argo-cd.md
@@ -174,6 +174,14 @@ data:
             end
           end
 
+          if condition.type == "Installed" then
+            if condition.status == "False" then
+              health_status.status = "Degraded"
+              health_status.message = condition.message
+              return health_status
+            end
+          end
+
           if contains({"Ready", "Healthy", "Offered", "Established", "ValidPipeline", "RevisionHealthy"}, condition.type) then
             if condition.status == "True" then
               health_status.status = "Healthy"

--- a/content/v2.2/guides/crossplane-with-argo-cd.md
+++ b/content/v2.2/guides/crossplane-with-argo-cd.md
@@ -174,6 +174,14 @@ data:
             end
           end
 
+          if condition.type == "Installed" then
+            if condition.status == "False" then
+              health_status.status = "Degraded"
+              health_status.message = condition.message
+              return health_status
+            end
+          end
+
           if contains({"Ready", "Healthy", "Offered", "Established", "ValidPipeline", "RevisionHealthy"}, condition.type) then
             if condition.status == "True" then
               health_status.status = "Healthy"


### PR DESCRIPTION
Crossplane packages (Function, Provider, Configuration) expose two status conditions: `Installed` (the package spec resolved and was unpacked) and `Healthy` (the active PackageRevision is healthy). When `spec.package` is changed to a tag that cannot be resolved or unpacked, the new generation reports `Installed=False` (reason: `UnpackingPackage`, `InvalidPackageRevisionSpec`, ...), but the previously active revision continues to report `Healthy=True / HealthyPackageRevision` with a stale `observedGeneration`. The Lua healthcheck only matched positive condition types and therefore stamped the package as Healthy in ArgoCD even though the GitOps change had failed to roll out.

Add an explicit branch that early-returns Degraded when an `Installed` condition is False, mirroring the existing handling for `Synced` and `LastAsyncOperation`. The new branch is a no-op for non-package kinds and for the steady-state `Installed=True / ActivePackageRevision` case.


**Before - the error is unclear and hidden by Progressing:**

<img width="884" height="836" alt="image" src="https://github.com/user-attachments/assets/c80f0cad-11cb-47e2-9b0a-ed3d06dd634f" />

**After - the error is surface:**

<img width="892" height="732" alt="image" src="https://github.com/user-attachments/assets/3c7cb57f-6884-472e-b040-0f1b26df48a6" />
<img width="2176" height="1026" alt="image" src="https://github.com/user-attachments/assets/f8f5c4a2-f2bd-4469-9f40-bc140031cc49" />

<!--
Thanks for contributing to the docs! 

For information about local previews with Hugo read the contributing getting started guide:
https://docs.crossplane.io/contribute/contribute/

For information about Hugo's features like tabs and hint boxes read the styling features guide:
https://docs.crossplane.io/contribute/features/

For information on using Vale and testing locally read our Using Vale guide:
https://docs.crossplane.io/contribute/vale/

Need more help? Join the Crossplane Slack and ask in the #documentation channel.
https://slack.crossplane.io/
-->