### PR TITLE
Update CLI install instructions

### DIFF
--- a/content/master/cli/_index.md
+++ b/content/master/cli/_index.md
@@ -7,14 +7,20 @@ description: "Command-line tools for Crossplane development"
 The Crossplane CLI helps simplify some development and administration aspects of
 Crossplane.
 
-The Crossplane CLI includes:
-* tools to build, install, update and push Crossplane Packages
-* standalone Composition Function testing and rendering without the need to access a Kubernetes cluster running Crossplane
-* troubleshoot Crossplane Compositions, Composite Resources and Managed Resources
+The Crossplane CLI includes commands for:
+
+* building, installing, updating and pushing Crossplane Packages
+* building platforms using Crossplane Projects
+* testing and rendering standalone Composition Functions without the need to
+  access a Kubernetes cluster running Crossplane
+* troubleshooting Crossplane Compositions, Composite Resources and Managed
+  Resources
 
 ## Installing the CLI
 
-The Crossplane CLI is a single standalone binary with no external dependencies.
+The Crossplane CLI is a single standalone binary with no external
+dependencies. Some commands, such as `crossplane composition render` and
+`crossplane project build`, do require a Docker compatible container runtime.
 
 {{<hint "note" >}}
 Install the Crossplane CLI on a user's computer.
@@ -23,50 +29,44 @@ Most Crossplane CLI commands are independent of Kubernetes and
 don't require access to a Crossplane pod.
 {{< /hint >}}
 
-To download the latest version for your CPU architecture with the Crossplane
-install script.
+You can download the latest version using the install script:
 
 ```shell
-curl -sL "https://raw.githubusercontent.com/crossplane/crossplane/main/install.sh" | sh
+curl -sfL "https://cli.crossplane.io/install.sh" | sh
 ```
 
-[The script](https://raw.githubusercontent.com/crossplane/crossplane/main/install.sh)
-detects your CPU architecture and downloads the latest stable release.
+[The script](https://raw.githubusercontent.com/crossplane/cli/main/install.sh)
+detects your operating system and CPU architecture and downloads the appropriate
+binary to the current directory. Note that it doesn't attempt to place the
+binary in your shell's `$PATH`, so you may want to move it.
 
 {{<expand "Manually install the Crossplane CLI" >}}
 
 If you don't want to run shell script you can manually download a binary from
 the Crossplane releases repository at
-https://releases.crossplane.io/stable/current/bin
-
-{{<hint "important" >}}
-<!-- vale write-good.Passive = NO -->
-The release repository names the CLI `crank`. Download this file.
-<!-- vale write-good.Passive = YES -->
-
-The `crossplane` binary is the Kubernetes Crossplane pod image.
-{{< /hint >}}
+https://cli.crossplane.io/stable/current/bin
 
 Move the binary to a location in your `$PATH`, for example `/usr/local/bin`.
 {{< /expand >}}
 
 ### Download other CLI versions
 
-Download different Crossplane CLI versions or different release branches with
-the `XP_CHANNEL` and `XP_VERSION` environmental variables.
+You can download different Crossplane CLI versions or different release branches
+with the `XP_CHANNEL` and `XP_VERSION` environmental variables.
 
 By default the CLI installs from the `XP_CHANNEL` named `stable` and the
 `XP_VERSION` of `current`, matching the most recent stable release.
 
-For example, to install CLI version `v1.20.0` add `XP_VERSION=v1.20.0` to the
+For example, to install CLI version `v2.3.0` add `XP_VERSION=v2.3.0` to the
 download script curl command:
 
 ```shell
-curl -sL "https://raw.githubusercontent.com/crossplane/crossplane/main/install.sh" | XP_VERSION=v1.20.0 sh
+curl -sfL "https://cli.crossplane.io/install.sh" | XP_VERSION=v2.3.0 sh
 ```
 
-To install the CLI from the `master` channel add `XP_CHANNEL=master`:
+To install the latest build from the `main` branch, use the `master` channel by
+adding `XP_CHANNEL=master`:
 
 ```shell
-curl -sL "https://raw.githubusercontent.com/crossplane/crossplane/main/install.sh" | XP_CHANNEL=master sh
+curl -sfL "https://cli.crossplane.io/install.sh" | XP_CHANNEL=master sh
 ```

--- a/content/v2.3/cli/_index.md
+++ b/content/v2.3/cli/_index.md
@@ -7,14 +7,20 @@ description: "Command-line tools for Crossplane development"
 The Crossplane CLI helps simplify some development and administration aspects of
 Crossplane.
 
-The Crossplane CLI includes:
-* tools to build, install, update and push Crossplane Packages
-* standalone Composition Function testing and rendering without the need to access a Kubernetes cluster running Crossplane
-* troubleshoot Crossplane Compositions, Composite Resources and Managed Resources
+The Crossplane CLI includes commands for:
+
+* building, installing, updating and pushing Crossplane Packages
+* building platforms using Crossplane Projects
+* testing and rendering standalone Composition Functions without the need to
+  access a Kubernetes cluster running Crossplane
+* troubleshooting Crossplane Compositions, Composite Resources and Managed
+  Resources
 
 ## Installing the CLI
 
-The Crossplane CLI is a single standalone binary with no external dependencies.
+The Crossplane CLI is a single standalone binary with no external
+dependencies. Some commands, such as `crossplane composition render` and
+`crossplane project build`, do require a Docker compatible container runtime.
 
 {{<hint "note" >}}
 Install the Crossplane CLI on a user's computer.
@@ -23,50 +29,44 @@ Most Crossplane CLI commands are independent of Kubernetes and
 don't require access to a Crossplane pod.
 {{< /hint >}}
 
-To download the latest version for your CPU architecture with the Crossplane
-install script.
+You can download the latest version using the install script:
 
 ```shell
-curl -sL "https://raw.githubusercontent.com/crossplane/crossplane/main/install.sh" | sh
+curl -sfL "https://cli.crossplane.io/install.sh" | sh
 ```
 
-[The script](https://raw.githubusercontent.com/crossplane/crossplane/main/install.sh)
-detects your CPU architecture and downloads the latest stable release.
+[The script](https://raw.githubusercontent.com/crossplane/cli/main/install.sh)
+detects your operating system and CPU architecture and downloads the appropriate
+binary to the current directory. Note that it doesn't attempt to place the
+binary in your shell's `$PATH`, so you may want to move it.
 
 {{<expand "Manually install the Crossplane CLI" >}}
 
 If you don't want to run shell script you can manually download a binary from
 the Crossplane releases repository at
-https://releases.crossplane.io/stable/current/bin
-
-{{<hint "important" >}}
-<!-- vale write-good.Passive = NO -->
-The release repository names the CLI `crank`. Download this file.
-<!-- vale write-good.Passive = YES -->
-
-The `crossplane` binary is the Kubernetes Crossplane pod image.
-{{< /hint >}}
+https://cli.crossplane.io/stable/current/bin
 
 Move the binary to a location in your `$PATH`, for example `/usr/local/bin`.
 {{< /expand >}}
 
 ### Download other CLI versions
 
-Download different Crossplane CLI versions or different release branches with
-the `XP_CHANNEL` and `XP_VERSION` environmental variables.
+You can download different Crossplane CLI versions or different release branches
+with the `XP_CHANNEL` and `XP_VERSION` environmental variables.
 
 By default the CLI installs from the `XP_CHANNEL` named `stable` and the
 `XP_VERSION` of `current`, matching the most recent stable release.
 
-For example, to install CLI version `v1.20.0` add `XP_VERSION=v1.20.0` to the
+For example, to install CLI version `v2.3.0` add `XP_VERSION=v2.3.0` to the
 download script curl command:
 
 ```shell
-curl -sL "https://raw.githubusercontent.com/crossplane/crossplane/main/install.sh" | XP_VERSION=v1.20.0 sh
+curl -sfL "https://cli.crossplane.io/install.sh" | XP_VERSION=v2.3.0 sh
 ```
 
-To install the CLI from the `master` channel add `XP_CHANNEL=master`:
+To install the latest build from the `main` branch, use the `master` channel by
+adding `XP_CHANNEL=master`:
 
 ```shell
-curl -sL "https://raw.githubusercontent.com/crossplane/crossplane/main/install.sh" | XP_CHANNEL=master sh
+curl -sfL "https://cli.crossplane.io/install.sh" | XP_CHANNEL=master sh
 ```


### PR DESCRIPTION
Update the CLI install instructions to reference the new artifact location (cli.crossplane.io) and use the install script hosted there rather than pulling it directly from GitHub. While we're here, clarify the language a bit.
