### PR TITLE
Version the CLI documentation separately

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -23,8 +23,7 @@ jobs:
           extended: true
 
       - name: Build
-        # Set to env=dev so SCSS isn't required.
-        run: hugo --environment development
+        run: HUGO_ENV=development bash netlify_build.sh
 
       - name: Run htmltest
         uses: wjdp/htmltest-action@master

--- a/.github/workflows/weekly-link-checker.yml
+++ b/.github/workflows/weekly-link-checker.yml
@@ -22,8 +22,7 @@ jobs:
           extended: true
 
       - name: Build
-        # Set to env=dev so SCSS isn't required.
-        run: hugo --environment development
+        run: HUGO_ENV=development bash netlify_build.sh
 
       - name: Enable external link checking
         run: "sed -i 's/CheckExternal: false/CheckExternal: true/' utils/htmltest/.htmltest.yml"

--- a/config.yaml
+++ b/config.yaml
@@ -95,6 +95,9 @@ security:
 params:
   # The current "latest" version. Used in the version dropdown
   latest: "2.3"
+  # The current "latest" version of the CLI docs. Used in the CLI version
+  # dropdown. Tracked separately from the core "latest" so the two can diverge.
+  cliLatest: "2.3"
   docs: true
   anchors:
     # Generate heading anchors for any heading between min and max

--- a/content/cli/_index.md
+++ b/content/cli/_index.md
@@ -1,0 +1,11 @@
+---
+title: "CLI Reference"
+# /cli/ is the unversioned parent of the CLI version sections. Redirect it to the
+# build-time "latest" CLI copy, mirroring how the site root redirects to the
+# latest core version.
+layout: redirect
+to: "/cli/latest/"
+cascade:
+    track: "cli"
+    docs: false
+---

--- a/content/cli/master/_index.md
+++ b/content/cli/master/_index.md
@@ -1,7 +1,9 @@
 ---
-weight: 200
-title: CLI Reference
+weight: 50
+title: CLI Overview
 description: "Command-line tools for Crossplane development"
+cascade:
+    version: "master"
 ---
 
 The Crossplane CLI helps simplify some development and administration aspects of

--- a/content/cli/master/command-reference.md
+++ b/content/cli/master/command-reference.md
@@ -1,5 +1,5 @@
 ---
-weight: 50
+weight: 100
 title: Command Reference
 description: "Command reference for the Crossplane CLI"
 ---

--- a/content/cli/v1.20/_index.md
+++ b/content/cli/v1.20/_index.md
@@ -77,7 +77,6 @@ source <(crossplane completions)
 
 {{<hint "note" >}}
 The `completions` command generates the autocompletions for your default shell.
-It's not possible to generate autocompletions for a different shell, if you want to
-install the autocompletions for a different shell, you have to configure the Crossplane
-CLI as the completer manually.
+To install the autocompletions for a different shell, you have to configure the
+Crossplane CLI as the completer manually.
 {{< /hint >}}

--- a/content/cli/v1.20/_index.md
+++ b/content/cli/v1.20/_index.md
@@ -1,7 +1,9 @@
 ---
-weight: 200
-title: CLI Reference
-description: "Command-line tools for Crossplane development"
+weight: 50
+title: CLI Overview
+description: "Documentation for the Crossplane command-line interface"
+cascade:
+    version: "1.20"
 ---
 
 The Crossplane CLI helps simplify some development and administration aspects of
@@ -17,11 +19,11 @@ The Crossplane CLI includes:
 The Crossplane CLI is a single standalone binary with no external dependencies.
 
 {{<hint "note" >}}
-Install the Crossplane CLI on a user's computer.
+Install the Crossplane CLI on a user's computer. 
 
-Most Crossplane CLI commands are independent of Kubernetes and
+Most Crossplane CLI commands are independent of Kubernetes and 
 don't require access to a Crossplane pod.
-{{< /hint >}}
+{{< /hint >}} 
 
 To download the latest version for your CPU architecture with the Crossplane
 install script.
@@ -35,13 +37,13 @@ detects your CPU architecture and downloads the latest stable release.
 
 {{<expand "Manually install the Crossplane CLI" >}}
 
-If you don't want to run shell script you can manually download a binary from
-the Crossplane releases repository at
+If you don't want to run shell script you can manually download a binary from 
+the Crossplane releases repository at 
 https://releases.crossplane.io/stable/current/bin
 
 {{<hint "important" >}}
 <!-- vale write-good.Passive = NO -->
-The release repository names the CLI `crank`. Download this file.
+The CLI is named `crank` in the release repository. Download this file. 
 <!-- vale write-good.Passive = YES -->
 
 The `crossplane` binary is the Kubernetes Crossplane pod image.
@@ -53,20 +55,29 @@ Move the binary to a location in your `$PATH`, for example `/usr/local/bin`.
 ### Download other CLI versions
 
 Download different Crossplane CLI versions or different release branches with
-the `XP_CHANNEL` and `XP_VERSION` environmental variables.
+the `XP_CHANNEL` and `XP_VERSION` environmental variables. 
 
-By default the CLI installs from the `XP_CHANNEL` named `stable` and the
+By default the CLI installs from the `XP_CHANNEL` named `stable` and the 
 `XP_VERSION` of `current`, matching the most recent stable release.
 
-For example, to install CLI version `v1.20.0` add `XP_VERSION=v1.20.0` to the
-download script curl command:
+For example, to install CLI version `v1.14.0` add `XP_VERSION=v1.14.0` to the 
+download script curl command:  
+
+`curl -sL "https://raw.githubusercontent.com/crossplane/crossplane/main/install.sh" | XP_VERSION=v1.14.0 sh`
+
+## Installing shell autocompletions
+
+The Crossplane CLI supports shell autocompletions for `bash`, `zsh` and `fish`.
+You can install the autocompletions with the `completions` command by adding it to
+your shell's configuration file.
 
 ```shell
-curl -sL "https://raw.githubusercontent.com/crossplane/crossplane/main/install.sh" | XP_VERSION=v1.20.0 sh
+source <(crossplane completions)
 ```
 
-To install the CLI from the `master` channel add `XP_CHANNEL=master`:
-
-```shell
-curl -sL "https://raw.githubusercontent.com/crossplane/crossplane/main/install.sh" | XP_CHANNEL=master sh
-```
+{{<hint "note" >}}
+The `completions` command generates the autocompletions for your default shell.
+It's not possible to generate autocompletions for a different shell, if you want to
+install the autocompletions for a different shell, you have to configure the Crossplane
+CLI as the completer manually.
+{{< /hint >}}

--- a/content/cli/v1.20/command-reference.md
+++ b/content/cli/v1.20/command-reference.md
@@ -1,5 +1,5 @@
 ---
-weight: 50
+weight: 100
 title: Command Reference
 description: "Command reference for the Crossplane CLI"
 ---
@@ -8,7 +8,7 @@ description: "Command reference for the Crossplane CLI"
 <!-- vale Google.Headings = NO -->
 The `crossplane` CLI provides utilities to make using Crossplane easier.
 
-Read the [Crossplane CLI overview]({{<ref "../cli">}}) page for information on
+Read the [Crossplane CLI overview]({{<ref "/cli/v1.20">}}) page for information on
 installing `crossplane`.
 
 ## Global flags
@@ -38,8 +38,8 @@ Server Version: v1.17.0
 ## render
 
 The `crossplane render` command previews the output of a
-[composite resource]({{<ref "../concepts/composite-resources">}}) after applying
-any [composition functions]({{<ref "../concepts/compositions">}}).
+[composite resource]({{<ref "/v1.20/concepts/composite-resources">}}) after applying
+any [composition functions]({{<ref "/v1.20/concepts/compositions">}}).
 
 {{< hint "important" >}}
 The `crossplane render` command requires you to use composition functions.
@@ -178,7 +178,7 @@ built-in support in [function-go-templating](https://github.com/crossplane-contr
 ## xpkg
 
 The `crossplane xpkg` commands create, install and update Crossplane
-[packages]({{<ref "../concepts/packages">}}) as well as enable authentication
+[packages]({{<ref "/v1.20/concepts/packages">}}) as well as enable authentication
 and publishing of Crossplane packages to a Crossplane package registry.
 
 ### xpkg build
@@ -193,9 +193,9 @@ The CLI applies the required annotations and values to meet the
 [Crossplane XPKG specification](https://github.com/crossplane/crossplane/blob/main/contributing/specifications/xpkg.md).
 
 The `crossplane` CLI supports building
-[configuration]({{< ref "../concepts/packages" >}}),
-[function]({{<ref "../concepts/compositions">}}) and
-[provider]({{<ref "../concepts/providers" >}}) package types.
+[configuration]({{< ref "/v1.20/concepts/packages" >}}),
+[function]({{<ref "/v1.20/concepts/compositions">}}) and
+[provider]({{<ref "/v1.20/concepts/providers" >}}) package types.
 
 #### Flags
 
@@ -270,9 +270,9 @@ with the command
 The `<name>` input isn't used. Crossplane reserves the `<name>` for future releases.
 
 The `<template>` value may be one of four well known templates:
-* `configuration-template` - A template to build a Crossplane [Configuration]({{<ref "../concepts/packages">}}) from the [crossplane/configuration-template](https://github.com/crossplane/configuration-template) repository.
-* `function-template-go` - A template to build Crossplane Go [composition functions]({{<ref "../concepts/compositions">}}) from the [crossplane/function-template-go](https://github.com/crossplane/function-template-go) repository.
-* `function-template-python` - A template to build Crossplane Python [composition functions]({{<ref "../concepts/compositions">}}) from the [crossplane/function-template-python](https://github.com/crossplane/function-template-go) repository.
+* `configuration-template` - A template to build a Crossplane [Configuration]({{<ref "/v1.20/concepts/packages">}}) from the [crossplane/configuration-template](https://github.com/crossplane/configuration-template) repository.
+* `function-template-go` - A template to build Crossplane Go [composition functions]({{<ref "/v1.20/concepts/compositions">}}) from the [crossplane/function-template-go](https://github.com/crossplane/function-template-go) repository.
+* `function-template-python` - A template to build Crossplane Python [composition functions]({{<ref "/v1.20/concepts/compositions">}}) from the [crossplane/function-template-python](https://github.com/crossplane/function-template-go) repository.
 * `provider-template` - A template to build a basic Crossplane provider from the [Crossplane/provider-template](https://github.com/crossplane/provider-template) repository.
 * `provider-template-upjet` - A template for building [Upjet](https://github.com/crossplane/upjet) based Crossplane providers from existing Terraform providers. Copies from the [upbound/upjet-provider-template](https://github.com/upbound/upjet-provider-template) repository.
 
@@ -352,7 +352,7 @@ returns an error if the `wait` time expires before the package is `HEALTHY`.
 #### Require manual package activation
 
 Set the package to require
-[manual activation]({{<ref "../concepts/packages#revision-activation-policy" >}}),
+[manual activation]({{<ref "/v1.20/concepts/packages#revision-activation-policy" >}}),
 preventing an automatic upgrade of a package with `--manual-activation`
 
 #### Authenticate to a private registry
@@ -372,7 +372,7 @@ cache.
 Store more inactive copies of a package with `--revision-history-limit`.
 
 Read more about
-[package revisions]({{< ref "../concepts/packages#configuration-revisions" >}})
+[package revisions]({{< ref "/v1.20/concepts/packages#configuration-revisions" >}})
 in the package documentation.
 
 ### xpkg login
@@ -515,10 +515,10 @@ migration to the new APIs and resources, the `crossplane beta convert` command
 converts a Crossplane resource to a new version or kind.
 
 Use the `crossplane beta convert` command to convert an existing
-[ControllerConfig]({{<ref "../concepts/providers#controller-configuration">}})
-to a [DeploymentRuntimeConfig]({{<ref "../concepts/providers#runtime-configuration">}})
+[ControllerConfig]({{<ref "/v1.20/concepts/providers#controller-configuration">}})
+to a [DeploymentRuntimeConfig]({{<ref "/v1.20/concepts/providers#runtime-configuration">}})
 or a legacy Composition using `mode: Resources` to a
-[Composition pipeline function]({{< ref "../concepts/compositions" >}}).
+[Composition pipeline function]({{< ref "/v1.20/concepts/compositions" >}}).
 
 Provide the `crossplane beta convert` command the conversion type, the input
 file and optionally, an output file. By default the command writes the output to
@@ -887,9 +887,10 @@ so there's nothing to scan on a cluster already running v2.
 The command looks for:
 
 * **Native patch and transform Compositions**, which v2 removes in favor of
-  [composition functions]({{<ref "../concepts/compositions">}}).
+  [composition functions]({{<ref "/v1.20/concepts/compositions">}}).
 * **`ControllerConfig` usage**, including Providers and Functions that still
-  reference one. v2 removes the type in favor of [`DeploymentRuntimeConfig`]({{<ref "../concepts/providers/#configuring-runtime-deployment-spec">}}).
+  reference one. v2 removes the type in favor of
+  [`DeploymentRuntimeConfig`]({{<ref "/v1.20/concepts/providers/#configuring-runtime-deployment-spec">}}).
 * **External secret stores**, an alpha feature that v2 removes.
 * **Composite resource connection details**. v2 keeps these working for legacy
   XRs, so the command reports them as informational rather than as a blocker.
@@ -992,7 +993,7 @@ processes in parallel:
 ### beta validate
 
 The `crossplane beta validate` command validates
-[compositions]({{<ref "../concepts/compositions">}}) against provider or XRD
+[compositions]({{<ref "/v1.20/concepts/compositions">}}) against provider or XRD
 schemas using the Kubernetes API server's validation library
 with extra validation such as checking for unknown fields,
 a common source of difficult to debug issues in Crossplane.

--- a/content/cli/v2.1/_index.md
+++ b/content/cli/v2.1/_index.md
@@ -1,7 +1,9 @@
 ---
-weight: 200
-title: CLI Reference
+weight: 50
+title: CLI Overview
 description: "Command-line tools for Crossplane development"
+cascade:
+    version: "2.1"
 ---
 
 The Crossplane CLI helps simplify some development and administration aspects of

--- a/content/cli/v2.1/command-reference.md
+++ b/content/cli/v2.1/command-reference.md
@@ -1,5 +1,5 @@
 ---
-weight: 50
+weight: 100
 title: Command Reference
 description: "Command reference for the Crossplane CLI"
 ---
@@ -8,7 +8,7 @@ description: "Command reference for the Crossplane CLI"
 <!-- vale Google.Headings = NO -->
 The `crossplane` CLI provides utilities to make using Crossplane easier.
 
-Read the [Crossplane CLI overview]({{<ref "../cli">}}) page for information on
+Read the [Crossplane CLI overview]({{<ref "/cli/v2.1">}}) page for information on
 installing `crossplane`.
 
 ## Global flags
@@ -44,8 +44,8 @@ Server Version: v1.17.0
 <!-- vale Google.Headings = YES -->
 
 The `crossplane render` command previews the output of a
-[composite resource]({{<ref "../composition/composite-resources">}}) after applying
-any [composition functions]({{<ref "../composition/compositions">}}).
+[composite resource]({{<ref "/v2.1/composition/composite-resources">}}) after applying
+any [composition functions]({{<ref "/v2.1/composition/compositions">}}).
 
 {{< hint "important" >}}
 The `crossplane render` command requires you to use composition functions.
@@ -187,7 +187,7 @@ built-in support in [function-go-templating](https://github.com/crossplane-contr
 <!-- vale Google.Headings = YES -->
 
 The `crossplane xpkg` commands create, install and update Crossplane
-[packages]({{<ref "../packages/configurations">}}) and enable authentication
+[packages]({{<ref "/v2.1/packages/configurations">}}) and enable authentication
 and publishing of Crossplane packages to a Crossplane package registry.
 
 <!-- vale Google.Headings = NO -->
@@ -204,9 +204,9 @@ The CLI applies the required annotations and values to meet the
 [Crossplane XPKG specification](https://github.com/crossplane/crossplane/blob/main/contributing/specifications/xpkg.md).
 
 The `crossplane` CLI supports building
-[configuration]({{< ref "../packages/configurations" >}}),
-[function]({{<ref "../composition/compositions">}}) and
-[provider]({{<ref "../packages/providers" >}}) package types.
+[configuration]({{< ref "/v2.1/packages/configurations" >}}),
+[function]({{<ref "/v2.1/composition/compositions">}}) and
+[provider]({{<ref "/v2.1/packages/providers" >}}) package types.
 
 #### Flags
 
@@ -283,9 +283,9 @@ with the command
 The `<name>` input isn't used. Crossplane reserves the `<name>` for future releases.
 
 The `<template>` value may be one of four well known templates:
-* `configuration-template` - A template to build a Crossplane [Configuration]({{<ref "../packages/configurations">}}) from the [crossplane/configuration-template](https://github.com/crossplane/configuration-template) repository.
-* `function-template-go` - A template to build Crossplane Go [composition functions]({{<ref "../composition/compositions">}}) from the [crossplane/function-template-go](https://github.com/crossplane/function-template-go) repository.
-* `function-template-python` - A template to build Crossplane Python [composition functions]({{<ref "../composition/compositions">}}) from the [crossplane/function-template-python](https://github.com/crossplane/function-template-go) repository.
+* `configuration-template` - A template to build a Crossplane [Configuration]({{<ref "/v2.1/packages/configurations">}}) from the [crossplane/configuration-template](https://github.com/crossplane/configuration-template) repository.
+* `function-template-go` - A template to build Crossplane Go [composition functions]({{<ref "/v2.1/composition/compositions">}}) from the [crossplane/function-template-go](https://github.com/crossplane/function-template-go) repository.
+* `function-template-python` - A template to build Crossplane Python [composition functions]({{<ref "/v2.1/composition/compositions">}}) from the [crossplane/function-template-python](https://github.com/crossplane/function-template-go) repository.
 * `provider-template` - A template to build a basic Crossplane provider from the [Crossplane/provider-template](https://github.com/crossplane/provider-template) repository.
 * `provider-template-upjet` - A template for building [Upjet](https://github.com/crossplane/upjet) based Crossplane providers from existing Terraform providers. Copies from the [upbound/upjet-provider-template](https://github.com/upbound/upjet-provider-template) repository.
 
@@ -371,7 +371,7 @@ returns an error if the `wait` time expires before the package is `HEALTHY`.
 #### Require manual package activation
 
 Set the package to require
-[manual activation]({{<ref "../packages/configurations#revision-activation-policy" >}}),
+[manual activation]({{<ref "/v2.1/packages/configurations#revision-activation-policy" >}}),
 preventing an automatic upgrade of a package with `--manual-activation`
 
 #### Authenticate to a private registry
@@ -391,7 +391,7 @@ cache.
 Store more inactive copies of a package with `--revision-history-limit`.
 
 Read more about
-[package revisions]({{< ref "../packages/configurations#configuration-revisions" >}})
+[package revisions]({{< ref "/v2.1/packages/configurations#configuration-revisions" >}})
 in the package documentation.
 
 <!-- vale Google.Headings = NO -->
@@ -546,9 +546,9 @@ migration to the new APIs and resources, the `crossplane beta convert` command
 converts a Crossplane resource to a new version or kind.
 
 Use the `crossplane beta convert` command to convert a
-ControllerConfig to a [DeploymentRuntimeConfig]({{<ref "../packages/providers#runtime-configuration">}})
+ControllerConfig to a [DeploymentRuntimeConfig]({{<ref "/v2.1/packages/providers#runtime-configuration">}})
 or a legacy Composition using `mode: Resources` to a
-[Composition pipeline function]({{< ref "../composition/compositions" >}}).
+[Composition pipeline function]({{< ref "/v2.1/composition/compositions" >}}).
 
 Provide the `crossplane beta convert` command the conversion type, the input
 file and optionally, an output file. By default the command writes the output to
@@ -873,7 +873,7 @@ Configuration/platform-ref-aws                             v0.9.0    True       
 <!-- vale Google.Headings = YES -->
 
 The `crossplane beta validate` command validates
-[compositions]({{<ref "../composition/compositions">}}) against provider or XRD
+[compositions]({{<ref "/v2.1/composition/compositions">}}) against provider or XRD
 schemas using the Kubernetes API server's validation library
 with extra validation such as checking for unknown fields,
 a common source of difficult to debug issues in Crossplane.

--- a/content/cli/v2.2/_index.md
+++ b/content/cli/v2.2/_index.md
@@ -1,7 +1,9 @@
 ---
-weight: 200
-title: CLI Reference
-description: "Documentation for the Crossplane command-line interface"
+weight: 50
+title: CLI Overview
+description: "Command-line tools for Crossplane development"
+cascade:
+    version: "2.2"
 ---
 
 The Crossplane CLI helps simplify some development and administration aspects of
@@ -17,11 +19,11 @@ The Crossplane CLI includes:
 The Crossplane CLI is a single standalone binary with no external dependencies.
 
 {{<hint "note" >}}
-Install the Crossplane CLI on a user's computer. 
+Install the Crossplane CLI on a user's computer.
 
-Most Crossplane CLI commands are independent of Kubernetes and 
+Most Crossplane CLI commands are independent of Kubernetes and
 don't require access to a Crossplane pod.
-{{< /hint >}} 
+{{< /hint >}}
 
 To download the latest version for your CPU architecture with the Crossplane
 install script.
@@ -35,13 +37,13 @@ detects your CPU architecture and downloads the latest stable release.
 
 {{<expand "Manually install the Crossplane CLI" >}}
 
-If you don't want to run shell script you can manually download a binary from 
-the Crossplane releases repository at 
+If you don't want to run shell script you can manually download a binary from
+the Crossplane releases repository at
 https://releases.crossplane.io/stable/current/bin
 
 {{<hint "important" >}}
 <!-- vale write-good.Passive = NO -->
-The CLI is named `crank` in the release repository. Download this file. 
+The release repository names the CLI `crank`. Download this file.
 <!-- vale write-good.Passive = YES -->
 
 The `crossplane` binary is the Kubernetes Crossplane pod image.
@@ -53,29 +55,20 @@ Move the binary to a location in your `$PATH`, for example `/usr/local/bin`.
 ### Download other CLI versions
 
 Download different Crossplane CLI versions or different release branches with
-the `XP_CHANNEL` and `XP_VERSION` environmental variables. 
+the `XP_CHANNEL` and `XP_VERSION` environmental variables.
 
-By default the CLI installs from the `XP_CHANNEL` named `stable` and the 
+By default the CLI installs from the `XP_CHANNEL` named `stable` and the
 `XP_VERSION` of `current`, matching the most recent stable release.
 
-For example, to install CLI version `v1.14.0` add `XP_VERSION=v1.14.0` to the 
-download script curl command:  
-
-`curl -sL "https://raw.githubusercontent.com/crossplane/crossplane/main/install.sh" | XP_VERSION=v1.14.0 sh`
-
-## Installing shell autocompletions
-
-The Crossplane CLI supports shell autocompletions for `bash`, `zsh` and `fish`.
-You can install the autocompletions with the `completions` command by adding it to
-your shell's configuration file.
+For example, to install CLI version `v1.20.0` add `XP_VERSION=v1.20.0` to the
+download script curl command:
 
 ```shell
-source <(crossplane completions)
+curl -sL "https://raw.githubusercontent.com/crossplane/crossplane/main/install.sh" | XP_VERSION=v1.20.0 sh
 ```
 
-{{<hint "note" >}}
-The `completions` command generates the autocompletions for your default shell.
-It's not possible to generate autocompletions for a different shell, if you want to
-install the autocompletions for a different shell, you have to configure the Crossplane
-CLI as the completer manually.
-{{< /hint >}}
+To install the CLI from the `master` channel add `XP_CHANNEL=master`:
+
+```shell
+curl -sL "https://raw.githubusercontent.com/crossplane/crossplane/main/install.sh" | XP_CHANNEL=master sh
+```

--- a/content/cli/v2.2/command-reference.md
+++ b/content/cli/v2.2/command-reference.md
@@ -1,5 +1,5 @@
 ---
-weight: 50
+weight: 100
 title: Command Reference
 description: "Command reference for the Crossplane CLI"
 ---
@@ -8,7 +8,7 @@ description: "Command reference for the Crossplane CLI"
 <!-- vale Google.Headings = NO -->
 The `crossplane` CLI provides utilities to make using Crossplane easier.
 
-Read the [Crossplane CLI overview]({{<ref "../cli">}}) page for information on
+Read the [Crossplane CLI overview]({{<ref "/cli/v2.2">}}) page for information on
 installing `crossplane`.
 
 ## Global flags
@@ -44,8 +44,8 @@ Server Version: v1.17.0
 <!-- vale Google.Headings = YES -->
 
 The `crossplane render` command previews the output of a
-[composite resource]({{<ref "../composition/composite-resources">}}) after applying
-any [composition functions]({{<ref "../composition/compositions">}}).
+[composite resource]({{<ref "/v2.2/composition/composite-resources">}}) after applying
+any [composition functions]({{<ref "/v2.2/composition/compositions">}}).
 
 {{< hint "important" >}}
 The `crossplane render` command requires you to use composition functions.
@@ -187,7 +187,7 @@ built-in support in [function-go-templating](https://github.com/crossplane-contr
 <!-- vale Google.Headings = YES -->
 
 The `crossplane xpkg` commands create, install and update Crossplane
-[packages]({{<ref "../packages/configurations">}}) and enable authentication
+[packages]({{<ref "/v2.2/packages/configurations">}}) and enable authentication
 and publishing of Crossplane packages to a Crossplane package registry.
 
 <!-- vale Google.Headings = NO -->
@@ -204,9 +204,9 @@ The CLI applies the required annotations and values to meet the
 [Crossplane XPKG specification](https://github.com/crossplane/crossplane/blob/main/contributing/specifications/xpkg.md).
 
 The `crossplane` CLI supports building
-[configuration]({{< ref "../packages/configurations" >}}),
-[function]({{<ref "../composition/compositions">}}) and
-[provider]({{<ref "../packages/providers" >}}) package types.
+[configuration]({{< ref "/v2.2/packages/configurations" >}}),
+[function]({{<ref "/v2.2/composition/compositions">}}) and
+[provider]({{<ref "/v2.2/packages/providers" >}}) package types.
 
 #### Flags
 
@@ -283,9 +283,9 @@ with the command
 The `<name>` input isn't used. Crossplane reserves the `<name>` for future releases.
 
 The `<template>` value may be one of four well known templates:
-* `configuration-template` - A template to build a Crossplane [Configuration]({{<ref "../packages/configurations">}}) from the [crossplane/configuration-template](https://github.com/crossplane/configuration-template) repository.
-* `function-template-go` - A template to build Crossplane Go [composition functions]({{<ref "../composition/compositions">}}) from the [crossplane/function-template-go](https://github.com/crossplane/function-template-go) repository.
-* `function-template-python` - A template to build Crossplane Python [composition functions]({{<ref "../composition/compositions">}}) from the [crossplane/function-template-python](https://github.com/crossplane/function-template-go) repository.
+* `configuration-template` - A template to build a Crossplane [Configuration]({{<ref "/v2.2/packages/configurations">}}) from the [crossplane/configuration-template](https://github.com/crossplane/configuration-template) repository.
+* `function-template-go` - A template to build Crossplane Go [composition functions]({{<ref "/v2.2/composition/compositions">}}) from the [crossplane/function-template-go](https://github.com/crossplane/function-template-go) repository.
+* `function-template-python` - A template to build Crossplane Python [composition functions]({{<ref "/v2.2/composition/compositions">}}) from the [crossplane/function-template-python](https://github.com/crossplane/function-template-go) repository.
 * `provider-template` - A template to build a basic Crossplane provider from the [Crossplane/provider-template](https://github.com/crossplane/provider-template) repository.
 * `provider-template-upjet` - A template for building [Upjet](https://github.com/crossplane/upjet) based Crossplane providers from existing Terraform providers. Copies from the [upbound/upjet-provider-template](https://github.com/upbound/upjet-provider-template) repository.
 
@@ -371,7 +371,7 @@ returns an error if the `wait` time expires before the package is `HEALTHY`.
 #### Require manual package activation
 
 Set the package to require
-[manual activation]({{<ref "../packages/configurations#revision-activation-policy" >}}),
+[manual activation]({{<ref "/v2.2/packages/configurations#revision-activation-policy" >}}),
 preventing an automatic upgrade of a package with `--manual-activation`
 
 #### Authenticate to a private registry
@@ -391,7 +391,7 @@ cache.
 Store more inactive copies of a package with `--revision-history-limit`.
 
 Read more about
-[package revisions]({{< ref "../packages/configurations#configuration-revisions" >}})
+[package revisions]({{< ref "/v2.2/packages/configurations#configuration-revisions" >}})
 in the package documentation.
 
 <!-- vale Google.Headings = NO -->
@@ -546,9 +546,9 @@ migration to the new APIs and resources, the `crossplane beta convert` command
 converts a Crossplane resource to a new version or kind.
 
 Use the `crossplane beta convert` command to convert a
-ControllerConfig to a [DeploymentRuntimeConfig]({{<ref "../packages/providers#runtime-configuration">}})
+ControllerConfig to a [DeploymentRuntimeConfig]({{<ref "/v2.2/packages/providers#runtime-configuration">}})
 or a legacy Composition using `mode: Resources` to a
-[Composition pipeline function]({{< ref "../composition/compositions" >}}).
+[Composition pipeline function]({{< ref "/v2.2/composition/compositions" >}}).
 
 Provide the `crossplane beta convert` command the conversion type, the input
 file and optionally, an output file. By default the command writes the output to
@@ -873,7 +873,7 @@ Configuration/platform-ref-aws                             v0.9.0    True       
 <!-- vale Google.Headings = YES -->
 
 The `crossplane beta validate` command validates
-[compositions]({{<ref "../composition/compositions">}}) against provider or XRD
+[compositions]({{<ref "/v2.2/composition/compositions">}}) against provider or XRD
 schemas using the Kubernetes API server's validation library
 with extra validation such as checking for unknown fields,
 a common source of difficult to debug issues in Crossplane.

--- a/content/cli/v2.3/_index.md
+++ b/content/cli/v2.3/_index.md
@@ -1,7 +1,9 @@
 ---
-weight: 200
-title: CLI Reference
+weight: 50
+title: CLI Overview
 description: "Command-line tools for Crossplane development"
+cascade:
+    version: "2.3"
 ---
 
 The Crossplane CLI helps simplify some development and administration aspects of

--- a/content/cli/v2.3/command-reference.md
+++ b/content/cli/v2.3/command-reference.md
@@ -1,5 +1,5 @@
 ---
-weight: 50
+weight: 100
 title: Command Reference
 description: "Command reference for the Crossplane CLI"
 ---

--- a/content/contribute/_index.md
+++ b/content/contribute/_index.md
@@ -4,7 +4,7 @@ weight: -1
 cascade:
     version: "0"
     docs: false
-    product: "Contributing Guide"
+    track: contributing
 ---
 
 The Crossplane Contributing Guide is for anyone interested in contributing to

--- a/content/master/_index.md
+++ b/content/master/_index.md
@@ -35,8 +35,9 @@ Crossplane organizes its documentation into the following sections:
 * [Guides]({{<ref "guides">}}) guide you through common use cases, like
   monitoring Crossplane or extending it by writing a composition function.
 
-* [CLI Reference]({{<ref "/cli/master">}}) documents the `crossplane` command-line
-  interface that you can use to configure a Crossplane control plane.
+* [Crossplane CLI Documentation]({{<ref "/cli/">}}) documents the `crossplane`
+  command-line interface that you can use to configure a Crossplane control
+  plane.
 
 * [API Reference]({{<ref "api">}}) documents the APIs that you can use to
   configure a Crossplane control plane.

--- a/content/master/_index.md
+++ b/content/master/_index.md
@@ -35,7 +35,7 @@ Crossplane organizes its documentation into the following sections:
 * [Guides]({{<ref "guides">}}) guide you through common use cases, like
   monitoring Crossplane or extending it by writing a composition function.
 
-* [CLI Reference]({{<ref "cli">}}) documents the `crossplane` command-line
+* [CLI Reference]({{<ref "/cli/master">}}) documents the `crossplane` command-line
   interface that you can use to configure a Crossplane control plane.
 
 * [API Reference]({{<ref "api">}}) documents the APIs that you can use to

--- a/content/master/composition/compositions.md
+++ b/content/master/composition/compositions.md
@@ -339,8 +339,8 @@ don't need a Crossplane control plane to do this. The Crossplane CLI uses Docker
 Engine to run functions.
 
 {{<hint "tip">}}
-See the [Crossplane CLI docs]({{<ref "/cli/master">}}) to
-learn how to install and use the Crossplane CLI.
+See the [Crossplane CLI docs]({{<ref "/cli/">}}) to learn how to install and use
+the Crossplane CLI.
 {{< /hint >}}
 
 {{<hint "important">}}

--- a/content/master/composition/compositions.md
+++ b/content/master/composition/compositions.md
@@ -339,7 +339,7 @@ don't need a Crossplane control plane to do this. The Crossplane CLI uses Docker
 Engine to run functions.
 
 {{<hint "tip">}}
-See the [Crossplane CLI docs]({{<ref "../cli">}}) to
+See the [Crossplane CLI docs]({{<ref "/cli/master">}}) to
 learn how to install and use the Crossplane CLI.
 {{< /hint >}}
 

--- a/content/master/guides/connection-details-composition.md
+++ b/content/master/guides/connection-details-composition.md
@@ -441,8 +441,8 @@ View all the composed resources (including the connection details `Secret`)
 together using the `crossplane` CLI.
 
 {{<hint "tip">}}
-See the [Crossplane CLI docs]({{<ref "/cli/master">}}) to
-learn how to install and use the Crossplane CLI.
+See the [Crossplane CLI docs]({{<ref "/cli/">}}) to learn how to install
+and use the Crossplane CLI.
 {{< /hint >}}
 
 ```shell {copy-lines="1"}

--- a/content/master/guides/connection-details-composition.md
+++ b/content/master/guides/connection-details-composition.md
@@ -441,7 +441,7 @@ View all the composed resources (including the connection details `Secret`)
 together using the `crossplane` CLI.
 
 {{<hint "tip">}}
-See the [Crossplane CLI docs]({{<ref "../cli">}}) to
+See the [Crossplane CLI docs]({{<ref "/cli/master">}}) to
 learn how to install and use the Crossplane CLI.
 {{< /hint >}}
 

--- a/content/master/guides/upgrade-to-crossplane-v2.md
+++ b/content/master/guides/upgrade-to-crossplane-v2.md
@@ -58,8 +58,8 @@ Crossplane v2 removes these deprecated features:
 
 {{<hint "tip" >}}
 The Crossplane CLI can find these features for you. Run
-[`crossplane beta upgrade check`]({{<ref "../../v1.20/cli/command-reference#beta-upgrade-check">}})
-with the [`v1.20` CLI]({{<ref "../../v1.20/cli#download-other-cli-versions">}}) against your control plane to scan for every removed feature
+[`crossplane beta upgrade check`]({{<ref "/cli/v1.20/command-reference#beta-upgrade-check">}})
+with the [`v1.20` CLI]({{<ref "/cli/v1.20/#download-other-cli-versions">}}) against your control plane to scan for every removed feature
 below and report the resources that need attention before you upgrade to v2.
 {{</hint>}}
 

--- a/content/master/guides/write-a-composition-function-in-go.md
+++ b/content/master/guides/write-a-composition-function-in-go.md
@@ -66,7 +66,7 @@ To write a function in Go you need:
 
 * [Go](https://go.dev/dl/) v1.23 or newer. The guide uses Go v1.23.
 * [Docker Engine](https://docs.docker.com/engine/). This guide uses Engine v24.
-* The [Crossplane CLI]({{<ref "../cli" >}}) v1.17 or newer. This guide uses Crossplane
+* The [Crossplane CLI]({{<ref "/cli/master" >}}) v1.17 or newer. This guide uses Crossplane
   CLI v1.17.
 
 {{<hint "note">}}

--- a/content/master/guides/write-a-composition-function-in-go.md
+++ b/content/master/guides/write-a-composition-function-in-go.md
@@ -66,8 +66,8 @@ To write a function in Go you need:
 
 * [Go](https://go.dev/dl/) v1.23 or newer. The guide uses Go v1.23.
 * [Docker Engine](https://docs.docker.com/engine/). This guide uses Engine v24.
-* The [Crossplane CLI]({{<ref "/cli/master" >}}) v1.17 or newer. This guide uses Crossplane
-  CLI v1.17.
+* The [Crossplane CLI]({{<ref "/cli/" >}}) v1.17 or newer. This guide uses
+  Crossplane CLI v1.17.
 
 {{<hint "note">}}
 You don't need access to a Kubernetes cluster or a Crossplane control plane to

--- a/content/master/guides/write-a-composition-function-in-python.md
+++ b/content/master/guides/write-a-composition-function-in-python.md
@@ -67,8 +67,8 @@ To write a function in Python you need:
 * [Python](https://www.python.org/downloads/) v3.11.
 * [Hatch](https://hatch.pypa.io/), a Python build tool. This guide uses v1.7.
 * [Docker Engine](https://docs.docker.com/engine/). This guide uses Engine v24.
-* The [Crossplane CLI]({{<ref "/cli/master" >}}) v1.14 or newer. This guide uses Crossplane
-  CLI v1.14.
+* The [Crossplane CLI]({{<ref "/cli/" >}}) v1.14 or newer. This guide uses
+  Crossplane CLI v1.14.
 
 {{<hint "note">}}
 You don't need access to a Kubernetes cluster or a Crossplane control plane to

--- a/content/master/guides/write-a-composition-function-in-python.md
+++ b/content/master/guides/write-a-composition-function-in-python.md
@@ -67,7 +67,7 @@ To write a function in Python you need:
 * [Python](https://www.python.org/downloads/) v3.11.
 * [Hatch](https://hatch.pypa.io/), a Python build tool. This guide uses v1.7.
 * [Docker Engine](https://docs.docker.com/engine/). This guide uses Engine v24.
-* The [Crossplane CLI]({{<ref "../cli" >}}) v1.14 or newer. This guide uses Crossplane
+* The [Crossplane CLI]({{<ref "/cli/master" >}}) v1.14 or newer. This guide uses Crossplane
   CLI v1.14.
 
 {{<hint "note">}}

--- a/content/master/operations/operation.md
+++ b/content/master/operations/operation.md
@@ -519,8 +519,8 @@ don't need a Crossplane control plane to do this. The Crossplane CLI uses Docker
 Engine to run functions.
 
 {{<hint "tip">}}
-See the [Crossplane CLI docs]({{<ref "/cli/master">}}) to
-learn how to install and use the Crossplane CLI.
+See the [Crossplane CLI docs]({{<ref "/cli/">}}) to learn how to install and use
+the Crossplane CLI.
 {{< /hint >}}
 
 {{<hint "important">}}

--- a/content/master/operations/operation.md
+++ b/content/master/operations/operation.md
@@ -519,7 +519,7 @@ don't need a Crossplane control plane to do this. The Crossplane CLI uses Docker
 Engine to run functions.
 
 {{<hint "tip">}}
-See the [Crossplane CLI docs]({{<ref "../cli">}}) to
+See the [Crossplane CLI docs]({{<ref "/cli/master">}}) to
 learn how to install and use the Crossplane CLI.
 {{< /hint >}}
 

--- a/content/master/packages/configurations.md
+++ b/content/master/packages/configurations.md
@@ -474,7 +474,7 @@ spec:
 ### Build the package
 
 Create the package using the
-[Crossplane CLI]({{<ref "../cli">}}) command
+[Crossplane CLI]({{<ref "/cli/master">}}) command
 `crossplane xpkg build --package-root=<directory>`.
 
 Where the `<directory>` is the directory containing the `crossplane.yaml` file

--- a/content/master/packages/configurations.md
+++ b/content/master/packages/configurations.md
@@ -473,8 +473,7 @@ spec:
 
 ### Build the package
 
-Create the package using the
-[Crossplane CLI]({{<ref "/cli/master">}}) command
+Create the package using the [Crossplane CLI]({{<ref "/cli/">}}) command
 `crossplane xpkg build --package-root=<directory>`.
 
 Where the `<directory>` is the directory containing the `crossplane.yaml` file

--- a/content/master/whats-new/_index.md
+++ b/content/master/whats-new/_index.md
@@ -273,8 +273,8 @@ Crossplane v2 makes the following breaking changes:
 
 {{<hint "tip" >}}
 The Crossplane CLI can find which of these features your control plane uses. Run
-[`crossplane beta upgrade check`]({{<ref "../../v1.20/cli/command-reference#beta-upgrade-check">}})
-with the [`v1.20` CLI]({{<ref "../../v1.20/cli#download-other-cli-versions">}}) against a `v1.x` control plane to scan for these breaking
+[`crossplane beta upgrade check`]({{<ref "/cli/v1.20/command-reference#beta-upgrade-check">}})
+with the [`v1.20` CLI]({{<ref "/cli/v1.20/#download-other-cli-versions">}}) against a `v1.x` control plane to scan for these breaking
 changes before upgrading to v2.
 {{</hint>}}
 

--- a/content/v1.20/concepts/compositions.md
+++ b/content/v1.20/concepts/compositions.md
@@ -109,7 +109,7 @@ but the feature is no longer maintained. Crossplane doesn't accept new
 `Resources` features, and only accepts security bug fixes.
 <!-- vale write-good.Passive = YES -->
 
-See the [CLI documentation]({{<ref "../cli/command-reference#beta-convert">}})
+See the [CLI documentation]({{<ref "/cli/v1.20/command-reference#beta-convert">}})
 to learn how to use the `crossplane beta convert` command to convert a legacy
 `Resources` Composition to the `Pipeline` mode.
 {{< /hint >}}
@@ -442,7 +442,7 @@ support `mode: Resources` Compositions.
 {{< /hint >}}
 
 {{<hint "tip">}}
-See the [Crossplane CLI docs]({{<ref "../cli">}}) to
+See the [Crossplane CLI docs]({{<ref "/cli/v1.20">}}) to
 learn how to install and use the Crossplane CLI.
 {{< /hint >}}
 

--- a/content/v1.20/concepts/packages.md
+++ b/content/v1.20/concepts/packages.md
@@ -280,24 +280,24 @@ Crossplane can automatically upgrade a package's dependency version to the minim
 valid version that satisfies all the constraints. It's an alpha feature that
 requires enabling with the `--enable-dependency-version-upgrades` flag.
 
-In some cases, dependency version downgrade is required for proceeding with
+Sometimes, Crossplane requires dependency version downgrade for proceeding with
 installations. Suppose configuration A, which depends on package X with the
 constraint`>=v0.0.0`, is installed on the control plane. In this case, the package
 manager installs the latest version of package X, such as `v3.0.0`. Later, you decide
 to install configuration B, which depends on package X with the constraint `<=v2.0.0`.
-Since version `v2.0.0` satisfies both conditions, package X must be downgraded to
-allow the installation of configuration B which is disabled by default.
+Since version `v2.0.0` satisfies both conditions, Crossplane must downgrade package X to
+allow the installation of configuration B, which Crossplane disables by default.
 
-Automatic dependency version downgrades is also an alpha feature that can be
-enabled with the `--enable-dependency-version-downgrades` flag. Downgrading a
-package can cause unexpected behavior, therefore, this option is disabled by
-default. After enabling this option, the package manager will automatically
-downgrade a package's dependency version to the maximum valid version that
-satisfies the constraints.
+For enabling automatic dependency version downgrades, there is a configuration
+option as a helm value `packageManager.enableAutomaticDependencyDowngrade=true`.
+Downgrading a package can cause unexpected behavior, so this
+Crossplane disables this option by default. After enabling this option, the package manager
+automatically downgrades a package's dependency version to the maximum valid version
+that satisfies the constraints.
 
 {{<hint "note" >}}
 This configuration requires the `--enable-dependency-version-upgrades` flag.
-Please check the
+Please see the
 [configuration options]({{<ref "../software/install#customize-the-crossplane-helm-chart">}})
 and
 [feature flags]({{<ref "../software/install#feature-flags">}})
@@ -311,7 +311,7 @@ Enabling automatic dependency downgrades may have unintended consequences, such 
 
 1) CRDs missing in the downgraded version, possibly leaving orphaned MRs without
 controllers to reconcile them.
-2) Loss of data if downgraded CRD versions omit fields that were set before.
+2) Loss of data if downgraded CRD versions omit fields that you set before.
 3) Changes in the CRD storage version, which may prevent package version update.
 {{</hint >}}
 

--- a/content/v1.20/concepts/packages.md
+++ b/content/v1.20/concepts/packages.md
@@ -475,7 +475,7 @@ spec:
 ### Build the package
 
 Create the package using the
-[Crossplane CLI]({{<ref "../cli">}}) command
+[Crossplane CLI]({{<ref "/cli/v1.20">}}) command
 `crossplane xpkg build --package-root=<directory>`.
 
 Where the `<directory>` is the directory containing the `crossplane.yaml` file

--- a/content/v1.20/guides/write-a-composition-function-in-go.md
+++ b/content/v1.20/guides/write-a-composition-function-in-go.md
@@ -66,7 +66,7 @@ To write a function in Go you need:
 
 * [Go](https://go.dev/dl/) v1.23 or newer. The guide uses Go v1.23.
 * [Docker Engine](https://docs.docker.com/engine/). This guide uses Engine v24.
-* The [Crossplane CLI]({{<ref "../cli" >}}) v1.17 or newer. This guide uses Crossplane
+* The [Crossplane CLI]({{<ref "/cli/v1.20" >}}) v1.17 or newer. This guide uses Crossplane
   CLI v1.17.
 
 {{<hint "note">}}

--- a/content/v1.20/guides/write-a-composition-function-in-python.md
+++ b/content/v1.20/guides/write-a-composition-function-in-python.md
@@ -67,7 +67,7 @@ To write a function in Python you need:
 * [Python](https://www.python.org/downloads/) v3.11.
 * [Hatch](https://hatch.pypa.io/), a Python build tool. This guide uses v1.7.
 * [Docker Engine](https://docs.docker.com/engine/). This guide uses Engine v24.
-* The [Crossplane CLI]({{<ref "../cli" >}}) v1.14 or newer. This guide uses Crossplane
+* The [Crossplane CLI]({{<ref "/cli/v1.20" >}}) v1.14 or newer. This guide uses Crossplane
   CLI v1.14.
 
 {{<hint "note">}}

--- a/content/v2.1/_index.md
+++ b/content/v2.1/_index.md
@@ -35,7 +35,7 @@ Crossplane organizes its documentation into the following sections:
 * [Guides]({{<ref "guides">}}) guide you through common use cases, like
   monitoring Crossplane or extending it by writing a composition function.
 
-* [CLI Reference]({{<ref "cli">}}) documents the `crossplane` command-line
+* [CLI Reference]({{<ref "/cli/v2.1">}}) documents the `crossplane` command-line
   interface that you can use to configure a Crossplane control plane.
 
 * [API Reference]({{<ref "api">}}) documents the APIs that you can use to

--- a/content/v2.1/composition/compositions.md
+++ b/content/v2.1/composition/compositions.md
@@ -339,7 +339,7 @@ don't need a Crossplane control plane to do this. The Crossplane CLI uses Docker
 Engine to run functions.
 
 {{<hint "tip">}}
-See the [Crossplane CLI docs]({{<ref "../cli">}}) to
+See the [Crossplane CLI docs]({{<ref "/cli/v2.1">}}) to
 learn how to install and use the Crossplane CLI.
 {{< /hint >}}
 

--- a/content/v2.1/guides/connection-details-composition.md
+++ b/content/v2.1/guides/connection-details-composition.md
@@ -441,7 +441,7 @@ View all the composed resources (including the connection details `Secret`)
 together using the `crossplane` CLI.
 
 {{<hint "tip">}}
-See the [Crossplane CLI docs]({{<ref "../cli">}}) to
+See the [Crossplane CLI docs]({{<ref "/cli/v2.1">}}) to
 learn how to install and use the Crossplane CLI.
 {{< /hint >}}
 

--- a/content/v2.1/guides/upgrade-to-crossplane-v2.md
+++ b/content/v2.1/guides/upgrade-to-crossplane-v2.md
@@ -58,8 +58,8 @@ Crossplane v2 removes these deprecated features:
 
 {{<hint "tip" >}}
 The Crossplane CLI can find these features for you. Run
-[`crossplane beta upgrade check`]({{<ref "../../v1.20/cli/command-reference#beta-upgrade-check">}})
-with the [`v1.20` CLI]({{<ref "../../v1.20/cli#download-other-cli-versions">}}) against your control plane to scan for every removed feature
+[`crossplane beta upgrade check`]({{<ref "/cli/v1.20/command-reference#beta-upgrade-check">}})
+with the [`v1.20` CLI]({{<ref "/cli/v1.20/#download-other-cli-versions">}}) against your control plane to scan for every removed feature
 below and report the resources that need attention before you upgrade to v2.
 {{</hint>}}
 

--- a/content/v2.1/guides/write-a-composition-function-in-go.md
+++ b/content/v2.1/guides/write-a-composition-function-in-go.md
@@ -66,7 +66,7 @@ To write a function in Go you need:
 
 * [Go](https://go.dev/dl/) v1.23 or newer. The guide uses Go v1.23.
 * [Docker Engine](https://docs.docker.com/engine/). This guide uses Engine v24.
-* The [Crossplane CLI]({{<ref "../cli" >}}) v1.17 or newer. This guide uses Crossplane
+* The [Crossplane CLI]({{<ref "/cli/v2.1" >}}) v1.17 or newer. This guide uses Crossplane
   CLI v1.17.
 
 {{<hint "note">}}

--- a/content/v2.1/guides/write-a-composition-function-in-python.md
+++ b/content/v2.1/guides/write-a-composition-function-in-python.md
@@ -67,7 +67,7 @@ To write a function in Python you need:
 * [Python](https://www.python.org/downloads/) v3.11.
 * [Hatch](https://hatch.pypa.io/), a Python build tool. This guide uses v1.7.
 * [Docker Engine](https://docs.docker.com/engine/). This guide uses Engine v24.
-* The [Crossplane CLI]({{<ref "../cli" >}}) v1.14 or newer. This guide uses Crossplane
+* The [Crossplane CLI]({{<ref "/cli/v2.1" >}}) v1.14 or newer. This guide uses Crossplane
   CLI v1.14.
 
 {{<hint "note">}}

--- a/content/v2.1/operations/operation.md
+++ b/content/v2.1/operations/operation.md
@@ -519,7 +519,7 @@ don't need a Crossplane control plane to do this. The Crossplane CLI uses Docker
 Engine to run functions.
 
 {{<hint "tip">}}
-See the [Crossplane CLI docs]({{<ref "../cli">}}) to
+See the [Crossplane CLI docs]({{<ref "/cli/v2.1">}}) to
 learn how to install and use the Crossplane CLI.
 {{< /hint >}}
 

--- a/content/v2.1/packages/configurations.md
+++ b/content/v2.1/packages/configurations.md
@@ -474,7 +474,7 @@ spec:
 ### Build the package
 
 Create the package using the
-[Crossplane CLI]({{<ref "../cli">}}) command
+[Crossplane CLI]({{<ref "/cli/v2.1">}}) command
 `crossplane xpkg build --package-root=<directory>`.
 
 Where the `<directory>` is the directory containing the `crossplane.yaml` file

--- a/content/v2.1/whats-new/_index.md
+++ b/content/v2.1/whats-new/_index.md
@@ -273,8 +273,8 @@ Crossplane v2 makes the following breaking changes:
 
 {{<hint "tip" >}}
 The Crossplane CLI can find which of these features your control plane uses. Run
-[`crossplane beta upgrade check`]({{<ref "../../v1.20/cli/command-reference#beta-upgrade-check">}})
-with the [`v1.20` CLI]({{<ref "../../v1.20/cli#download-other-cli-versions">}}) against a `v1.x` control plane to scan for these breaking
+[`crossplane beta upgrade check`]({{<ref "/cli/v1.20/command-reference#beta-upgrade-check">}})
+with the [`v1.20` CLI]({{<ref "/cli/v1.20/#download-other-cli-versions">}}) against a `v1.x` control plane to scan for these breaking
 changes before upgrading to v2.
 {{</hint>}}
 

--- a/content/v2.2/_index.md
+++ b/content/v2.2/_index.md
@@ -35,7 +35,7 @@ Crossplane organizes its documentation into the following sections:
 * [Guides]({{<ref "guides">}}) guide you through common use cases, like
   monitoring Crossplane or extending it by writing a composition function.
 
-* [CLI Reference]({{<ref "cli">}}) documents the `crossplane` command-line
+* [CLI Reference]({{<ref "/cli/v2.2">}}) documents the `crossplane` command-line
   interface that you can use to configure a Crossplane control plane.
 
 * [API Reference]({{<ref "api">}}) documents the APIs that you can use to

--- a/content/v2.2/composition/compositions.md
+++ b/content/v2.2/composition/compositions.md
@@ -339,7 +339,7 @@ don't need a Crossplane control plane to do this. The Crossplane CLI uses Docker
 Engine to run functions.
 
 {{<hint "tip">}}
-See the [Crossplane CLI docs]({{<ref "../cli">}}) to
+See the [Crossplane CLI docs]({{<ref "/cli/v2.2">}}) to
 learn how to install and use the Crossplane CLI.
 {{< /hint >}}
 

--- a/content/v2.2/guides/connection-details-composition.md
+++ b/content/v2.2/guides/connection-details-composition.md
@@ -441,7 +441,7 @@ View all the composed resources (including the connection details `Secret`)
 together using the `crossplane` CLI.
 
 {{<hint "tip">}}
-See the [Crossplane CLI docs]({{<ref "../cli">}}) to
+See the [Crossplane CLI docs]({{<ref "/cli/v2.2">}}) to
 learn how to install and use the Crossplane CLI.
 {{< /hint >}}
 

--- a/content/v2.2/guides/upgrade-to-crossplane-v2.md
+++ b/content/v2.2/guides/upgrade-to-crossplane-v2.md
@@ -58,8 +58,8 @@ Crossplane v2 removes these deprecated features:
 
 {{<hint "tip" >}}
 The Crossplane CLI can find these features for you. Run
-[`crossplane beta upgrade check`]({{<ref "../../v1.20/cli/command-reference#beta-upgrade-check">}})
-with the [`v1.20` CLI]({{<ref "../../v1.20/cli#download-other-cli-versions">}}) against your control plane to scan for every removed feature
+[`crossplane beta upgrade check`]({{<ref "/cli/v1.20/command-reference#beta-upgrade-check">}})
+with the [`v1.20` CLI]({{<ref "/cli/v1.20/#download-other-cli-versions">}}) against your control plane to scan for every removed feature
 below and report the resources that need attention before you upgrade to v2.
 {{</hint>}}
 

--- a/content/v2.2/guides/write-a-composition-function-in-go.md
+++ b/content/v2.2/guides/write-a-composition-function-in-go.md
@@ -66,7 +66,7 @@ To write a function in Go you need:
 
 * [Go](https://go.dev/dl/) v1.23 or newer. The guide uses Go v1.23.
 * [Docker Engine](https://docs.docker.com/engine/). This guide uses Engine v24.
-* The [Crossplane CLI]({{<ref "../cli" >}}) v1.17 or newer. This guide uses Crossplane
+* The [Crossplane CLI]({{<ref "/cli/v2.2" >}}) v1.17 or newer. This guide uses Crossplane
   CLI v1.17.
 
 {{<hint "note">}}

--- a/content/v2.2/guides/write-a-composition-function-in-python.md
+++ b/content/v2.2/guides/write-a-composition-function-in-python.md
@@ -67,7 +67,7 @@ To write a function in Python you need:
 * [Python](https://www.python.org/downloads/) v3.11.
 * [Hatch](https://hatch.pypa.io/), a Python build tool. This guide uses v1.7.
 * [Docker Engine](https://docs.docker.com/engine/). This guide uses Engine v24.
-* The [Crossplane CLI]({{<ref "../cli" >}}) v1.14 or newer. This guide uses Crossplane
+* The [Crossplane CLI]({{<ref "/cli/v2.2" >}}) v1.14 or newer. This guide uses Crossplane
   CLI v1.14.
 
 {{<hint "note">}}

--- a/content/v2.2/operations/operation.md
+++ b/content/v2.2/operations/operation.md
@@ -519,7 +519,7 @@ don't need a Crossplane control plane to do this. The Crossplane CLI uses Docker
 Engine to run functions.
 
 {{<hint "tip">}}
-See the [Crossplane CLI docs]({{<ref "../cli">}}) to
+See the [Crossplane CLI docs]({{<ref "/cli/v2.2">}}) to
 learn how to install and use the Crossplane CLI.
 {{< /hint >}}
 

--- a/content/v2.2/packages/configurations.md
+++ b/content/v2.2/packages/configurations.md
@@ -474,7 +474,7 @@ spec:
 ### Build the package
 
 Create the package using the
-[Crossplane CLI]({{<ref "../cli">}}) command
+[Crossplane CLI]({{<ref "/cli/v2.2">}}) command
 `crossplane xpkg build --package-root=<directory>`.
 
 Where the `<directory>` is the directory containing the `crossplane.yaml` file

--- a/content/v2.2/whats-new/_index.md
+++ b/content/v2.2/whats-new/_index.md
@@ -273,8 +273,8 @@ Crossplane v2 makes the following breaking changes:
 
 {{<hint "tip" >}}
 The Crossplane CLI can find which of these features your control plane uses. Run
-[`crossplane beta upgrade check`]({{<ref "../../v1.20/cli/command-reference#beta-upgrade-check">}})
-with the [`v1.20` CLI]({{<ref "../../v1.20/cli#download-other-cli-versions">}}) against a `v1.x` control plane to scan for these breaking
+[`crossplane beta upgrade check`]({{<ref "/cli/v1.20/command-reference#beta-upgrade-check">}})
+with the [`v1.20` CLI]({{<ref "/cli/v1.20/#download-other-cli-versions">}}) against a `v1.x` control plane to scan for these breaking
 changes before upgrading to v2.
 {{</hint>}}
 

--- a/content/v2.3/_index.md
+++ b/content/v2.3/_index.md
@@ -35,7 +35,7 @@ Crossplane organizes its documentation into the following sections:
 * [Guides]({{<ref "guides">}}) guide you through common use cases, like
   monitoring Crossplane or extending it by writing a composition function.
 
-* [CLI Reference]({{<ref "cli">}}) documents the `crossplane` command-line
+* [CLI Reference]({{<ref "/cli/v2.3">}}) documents the `crossplane` command-line
   interface that you can use to configure a Crossplane control plane.
 
 * [API Reference]({{<ref "api">}}) documents the APIs that you can use to

--- a/content/v2.3/composition/compositions.md
+++ b/content/v2.3/composition/compositions.md
@@ -339,7 +339,7 @@ don't need a Crossplane control plane to do this. The Crossplane CLI uses Docker
 Engine to run functions.
 
 {{<hint "tip">}}
-See the [Crossplane CLI docs]({{<ref "../cli">}}) to
+See the [Crossplane CLI docs]({{<ref "/cli/v2.3">}}) to
 learn how to install and use the Crossplane CLI.
 {{< /hint >}}
 

--- a/content/v2.3/guides/connection-details-composition.md
+++ b/content/v2.3/guides/connection-details-composition.md
@@ -441,7 +441,7 @@ View all the composed resources (including the connection details `Secret`)
 together using the `crossplane` CLI.
 
 {{<hint "tip">}}
-See the [Crossplane CLI docs]({{<ref "../cli">}}) to
+See the [Crossplane CLI docs]({{<ref "/cli/v2.3">}}) to
 learn how to install and use the Crossplane CLI.
 {{< /hint >}}
 

--- a/content/v2.3/guides/upgrade-to-crossplane-v2.md
+++ b/content/v2.3/guides/upgrade-to-crossplane-v2.md
@@ -58,8 +58,8 @@ Crossplane v2 removes these deprecated features:
 
 {{<hint "tip" >}}
 The Crossplane CLI can find these features for you. Run
-[`crossplane beta upgrade check`]({{<ref "../../v1.20/cli/command-reference#beta-upgrade-check">}})
-with the [`v1.20` CLI]({{<ref "../../v1.20/cli#download-other-cli-versions">}}) against your control plane to scan for every removed feature
+[`crossplane beta upgrade check`]({{<ref "/cli/v1.20/command-reference#beta-upgrade-check">}})
+with the [`v1.20` CLI]({{<ref "/cli/v1.20/#download-other-cli-versions">}}) against your control plane to scan for every removed feature
 below and report the resources that need attention before you upgrade to v2.
 {{</hint>}}
 

--- a/content/v2.3/guides/write-a-composition-function-in-go.md
+++ b/content/v2.3/guides/write-a-composition-function-in-go.md
@@ -66,7 +66,7 @@ To write a function in Go you need:
 
 * [Go](https://go.dev/dl/) v1.23 or newer. The guide uses Go v1.23.
 * [Docker Engine](https://docs.docker.com/engine/). This guide uses Engine v24.
-* The [Crossplane CLI]({{<ref "../cli" >}}) v1.17 or newer. This guide uses Crossplane
+* The [Crossplane CLI]({{<ref "/cli/v2.3" >}}) v1.17 or newer. This guide uses Crossplane
   CLI v1.17.
 
 {{<hint "note">}}

--- a/content/v2.3/guides/write-a-composition-function-in-python.md
+++ b/content/v2.3/guides/write-a-composition-function-in-python.md
@@ -67,7 +67,7 @@ To write a function in Python you need:
 * [Python](https://www.python.org/downloads/) v3.11.
 * [Hatch](https://hatch.pypa.io/), a Python build tool. This guide uses v1.7.
 * [Docker Engine](https://docs.docker.com/engine/). This guide uses Engine v24.
-* The [Crossplane CLI]({{<ref "../cli" >}}) v1.14 or newer. This guide uses Crossplane
+* The [Crossplane CLI]({{<ref "/cli/v2.3" >}}) v1.14 or newer. This guide uses Crossplane
   CLI v1.14.
 
 {{<hint "note">}}

--- a/content/v2.3/operations/operation.md
+++ b/content/v2.3/operations/operation.md
@@ -519,7 +519,7 @@ don't need a Crossplane control plane to do this. The Crossplane CLI uses Docker
 Engine to run functions.
 
 {{<hint "tip">}}
-See the [Crossplane CLI docs]({{<ref "../cli">}}) to
+See the [Crossplane CLI docs]({{<ref "/cli/v2.3">}}) to
 learn how to install and use the Crossplane CLI.
 {{< /hint >}}
 

--- a/content/v2.3/packages/configurations.md
+++ b/content/v2.3/packages/configurations.md
@@ -474,7 +474,7 @@ spec:
 ### Build the package
 
 Create the package using the
-[Crossplane CLI]({{<ref "../cli">}}) command
+[Crossplane CLI]({{<ref "/cli/v2.3">}}) command
 `crossplane xpkg build --package-root=<directory>`.
 
 Where the `<directory>` is the directory containing the `crossplane.yaml` file

--- a/content/v2.3/whats-new/_index.md
+++ b/content/v2.3/whats-new/_index.md
@@ -273,8 +273,8 @@ Crossplane v2 makes the following breaking changes:
 
 {{<hint "tip" >}}
 The Crossplane CLI can find which of these features your control plane uses. Run
-[`crossplane beta upgrade check`]({{<ref "../../v1.20/cli/command-reference#beta-upgrade-check">}})
-with the [`v1.20` CLI]({{<ref "../../v1.20/cli#download-other-cli-versions">}}) against a `v1.x` control plane to scan for these breaking
+[`crossplane beta upgrade check`]({{<ref "/cli/v1.20/command-reference#beta-upgrade-check">}})
+with the [`v1.20` CLI]({{<ref "/cli/v1.20/#download-other-cli-versions">}}) against a `v1.x` control plane to scan for these breaking
 changes before upgrading to v2.
 {{</hint>}}
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -171,6 +171,13 @@ from = "/knowledge-base/"
 to = "/latest/"
 status = 301
 
+# Redirect from the old CLI documentation path to the new CLI documentation
+# path.
+[[redirects]]
+from = "/:version/cli/*"
+to = "/cli/:version/:splat"
+status=301
+
 # Redirect requests for EOL version docs to latest. These might return 404 if
 # docs have moved around, but for many docs the redirect will work. This relies
 # on the fact that Netlify will not perform a redirect for a page that exists.

--- a/netlify_build.sh
+++ b/netlify_build.sh
@@ -3,6 +3,10 @@
 # Which which version is the "Latest"?
 LATEST_VER="2.3"
 
+# Which CLI docs version is the "Latest"? Tracked separately from core so the
+# two version lines can diverge. Keep in sync with params.cliLatest in config.yaml.
+CLI_LATEST_VER="2.3"
+
 # Make a copy of /content/$LATEST_VER to the directory /latest
 # Search indexing only points to /latest, this prevents broken or out of date
 # search results
@@ -11,6 +15,12 @@ cp -R content/v$LATEST_VER content/latest
 # Set the `version` front matter to prevent redirect issues with the version
 # drop-down menu.
 sed -i "s/^\s*version: \"$LATEST_VER\"//g" content/latest/_index.md
+
+# Make a copy of /content/cli/v$CLI_LATEST_VER to /content/cli/latest, mirroring
+# the core /latest copy. Strip only the version line; the cascaded `track: "cli"`
+# must survive so the copy stays on the CLI track.
+cp -R content/cli/v$CLI_LATEST_VER content/cli/latest
+sed -i "s/^\s*version: \"$CLI_LATEST_VER\"//g" content/cli/latest/_index.md
 
 # Enable Hugo writeStats to enable PurgeCSS optimizations.
 # docs: https://gohugo.io/getting-started/configuration/#configure-build

--- a/themes/geekboot/layouts/404.html
+++ b/themes/geekboot/layouts/404.html
@@ -54,6 +54,23 @@
           {{ end }}
 
           <br />
+          {{ $cli_sorted := partial "utils/sorted-versions" (dict "page" . "sections" (.Site.GetPage "/cli").Sections) }}
+          <strong>CLI Reference Versions:</strong><br />
+          {{ range $cli_sorted }}
+              {{ $versionPage := $.Site.GetPage (printf "/cli/v%s" .) | default ($.Site.GetPage (printf "/cli/%s" .)) }}
+              {{ with $versionPage }}
+                  <a href="{{ .Permalink }}">{{ if ne .Page.Params.version "master" }}v{{ end }}{{ .Page.Params.version }}</a>
+                  {{ if eq .Page.Params.version $.Site.Params.cliLatest }}
+                      <span class="badge rounded-pill latest">Latest</span>
+                  {{ end }}
+                  {{ if eq .Page.Params.version "master" }}
+                      <small><em>(unreleased upcoming version)</em></small>
+                  {{ end }}
+                  <br />
+              {{ end }}
+          {{ end }}
+
+          <br />
           <p><small>Looking for an older version? Archived versions are available as tags in the <a href="https://github.com/crossplane/docs/tags">GitHub repository</a> (e.g., v1.19-archive, v1.18-archive).</small></p>
 
           <br />

--- a/themes/geekboot/layouts/_default/sitemap.xml
+++ b/themes/geekboot/layouts/_default/sitemap.xml
@@ -7,6 +7,15 @@
     <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}
   </url>
   {{ end }}
+  {{/* CLI docs: only the build-time /cli/latest copy is indexed, mirroring core */}}
+  {{ with .Site.GetPage "/cli/latest" }}
+  {{ range where (.Pages | append .) ".Params.searchExclude" "ne" "true" }}
+  <url>
+    <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
+    <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}
+  </url>
+  {{ end }}
+  {{ end }}
   {{/* For KB and Contrib guides */}}
   {{ range where .Site.Pages "Params.version" "0" }}
   <url>

--- a/themes/geekboot/layouts/partials/docs-sidebar.html
+++ b/themes/geekboot/layouts/partials/docs-sidebar.html
@@ -1,18 +1,29 @@
 {{ $current := . }}
 
 <nav class="bd-links-nav w-100" aria-label="Docs navigation">
-  {{ with .Site.GetPage "section" .Section }}
+  {{/* Build the nav from the page's version section. For core pages .Section
+       (the first path segment, e.g. "v2.3") is that section. For nested CLI
+       pages .Section is "cli" (the unversioned parent), so use .CurrentSection —
+       the deepest enclosing section, i.e. the CLI version section the page
+       belongs to (cli/v2.3). The loop below treats $navRoot itself as a flat
+       heading whose pages render as top-level siblings (matching the
+       Contributing Guide), rather than nesting them under a redundant parent. */}}
+  {{ $navRoot := .Site.GetPage "section" .Section }}
+  {{ if eq .Section "cli" }}
+    {{ $navRoot = .CurrentSection }}
+  {{ end }}
+  {{ with $navRoot }}
     {{ $sectionPages := (.Pages | append .) }}
     {{ range $sectionPages.ByWeight }}
       {{ $expand := (eq $current .) }}
-      {{ $expand = (and (eq $current.CurrentSection .) (ne .FirstSection .)) }}
+      {{ $expand = (and (eq $current.CurrentSection .) (ne . $navRoot)) }}
       {{ $id := substr (sha1 .Permalink) 0 8 }}
 
       {{ if not .Page.Params.tocHidden }}
         <div class="section-container container pe-0 pt-1">
           <div class="container nav-container pe-0 d-flex w-100 {{if eq . $current}}active{{ else if $expand }}active-parent{{end}}">
             <a class="d-flex w-100 border-0" href="{{.Permalink}}">{{ .Title }} </a>
-            {{ if and .IsSection (ne .FirstSection .) }}
+            {{ if and .IsSection (ne . $navRoot) }}
               {{/* Don't put an expand icon on pages that aren't sections or the section index */}}
               <div class="d-flex flex-shrink-1 sidebar-control-container align-self-center">
                 <input type="checkbox" class="d-flex sidebar-checkbox" {{if $expand}}checked{{ end }} aria-label="Close or Expand {{.Title}} Section" />
@@ -23,7 +34,7 @@
               </div>
             {{ end }}
           </div>
-          {{ if ne .FirstSection . }}
+          {{ if ne . $navRoot }}
             {{ range .Pages }}
               {{ if not .Page.Params.tocHidden }}
                 <div class="container flex-row collapse {{if $expand}} show {{ end }}" id="collapse-{{$id }}">
@@ -39,12 +50,18 @@
     {{ end }}
   {{ end }}
 
+  <hr />
+
   {{ if not ($.Param "docs") }}
     {{ partialCached "sidebar/user-docs" . }}
   {{ end }}
 
-  {{ if ne .Page.Params.product "Contributing Guide" }}
+  {{ if ne .Page.Params.track "contributing" }}
     {{ partialCached "sidebar/contributing-guide" . }}
+  {{ end }}
+
+  {{ if ne .Page.Params.track "cli" }}
+    {{ partialCached "sidebar/cli" . }}
   {{ end }}
 
   {{ partialCached "sidebar/roadmap" . }}

--- a/themes/geekboot/layouts/partials/header.html
+++ b/themes/geekboot/layouts/partials/header.html
@@ -23,6 +23,25 @@
 
 {{/* Don't do the URL processing for KB and Contrib guides */}}
 {{ if not .Page.Params.Product }}
+  {{ if eq (.Page.Params.track | default "core") "cli" }}
+    {{/* CLI track: the version segment is the SECOND path element
+         (/cli/v2.3/...), and the build-time "latest" copy lives at /cli/latest/.
+         Map the version segment in place to /cli/latest/ rather than stripping
+         it. The /cli/latest/ copy itself (empty version) is canonical-to-self. */}}
+    {{ if .Page.Params.version }}
+        {{ $latestPath := .RelPermalink }}
+        {{ if eq .Page.Params.version "master" }}
+            {{ $latestPath = replaceRE "/cli/master/" "/cli/latest/" .RelPermalink }}
+        {{ else }}
+            {{ $latestPath = replaceRE "/cli/v[0-9.]+(-preview)?/" "/cli/latest/" .RelPermalink }}
+        {{ end }}
+        {{ $latestPath = strings.TrimRight "/" $latestPath }}
+        {{ $latestPage := .Site.GetPage $latestPath }}
+        {{ if $latestPage }}
+        <link rel="canonical" href="{{ $latestPage.Permalink }}">
+        {{ end }}
+    {{ end }}
+  {{ else }}
     {{/* Strip out the version from the path to get just the section + page */}}
     {{ $sectionPage := replaceRE (printf "v%s/" .Page.Params.version) "" .RelPermalink }}
 
@@ -46,7 +65,7 @@
     {{ if $latestPage }}
     <link rel="canonical" href="{{$latestPage.Permalink }}">
     {{ end }}
-
+  {{ end }}
 {{ else }}
     <link rel="canonical" href="{{.Permalink}}">
 {{ end }}

--- a/themes/geekboot/layouts/partials/master-version-alert.html
+++ b/themes/geekboot/layouts/partials/master-version-alert.html
@@ -4,12 +4,12 @@
             <svg class="bi flex-shrink-0" role="img" aria-label="Warning:"><use xlink:href="#fire"/></svg>
         </div>
         <div class="d-flex">
-            This document is for an unreleased version of Crossplane.
+            This document is for an unreleased version of {{ .productName }}.
         </div>
     </div>
     <div class="mt-3">
         <p>
-            This document applies to the Crossplane <code>master</code> branch and not to the latest release v{{.Site.Params.latest}}.
+            This document applies to the {{ .productName }} <code>master</code> branch and not to the latest release v{{ .latest }}.
         </p>
     </div>
 </div>

--- a/themes/geekboot/layouts/partials/old-version-alert.html
+++ b/themes/geekboot/layouts/partials/old-version-alert.html
@@ -4,12 +4,12 @@
             <svg class="bi flex-shrink-0" role="img" aria-label="Info:"><use xlink:href="#info"/></svg>
         </div>
         <div class="d-flex">
-            This document is for an older version of Crossplane.
+            This document is for an older version of {{ .productName }}.
         </div>
     </div>
     <div class="mt-3">
         <p>
-            This document applies to Crossplane v{{ .Page.Params.version }} and not to the latest release v{{.Site.Params.latest}}.
+            This document applies to {{ .productName }} v{{ .page.Params.version }} and not to the latest release v{{ .latest }}.
         </p>
     </div>
 </div>

--- a/themes/geekboot/layouts/partials/preview-version-alert.html
+++ b/themes/geekboot/layouts/partials/preview-version-alert.html
@@ -4,15 +4,15 @@
             <svg class="bi flex-shrink-0" role="img" aria-label="Info:"><use xlink:href="#info"/></svg>
         </div>
         <div class="d-flex">
-            This document is for a preview version of Crossplane.
+            This document is for a preview version of {{ .productName }}.
         </div>
     </div>
     <div class="mt-3">
         <p>
-            This document applies to Crossplane v{{ .Page.Params.version }} and not to the latest release v{{.Site.Params.latest}}.
+            This document applies to {{ .productName }} v{{ .page.Params.version }} and not to the latest release v{{ .latest }}.
             <br />
             <br />
-            <b>Don't use Crossplane v{{ .Page.Params.version }} in production.</b>
+            <b>Don't use {{ .productName }} v{{ .page.Params.version }} in production.</b>
         </p>
     </div>
 </div>

--- a/themes/geekboot/layouts/partials/sidebar/cli.html
+++ b/themes/geekboot/layouts/partials/sidebar/cli.html
@@ -1,0 +1,7 @@
+<div class="section-container container pe-0 pt-1">
+    <div class="nav-container">
+        <a href="{{.Site.BaseURL}}cli" class="d-inline-flex align-items-center">
+        Crossplane CLI Documentation
+        </a>
+    </div>
+</div>

--- a/themes/geekboot/layouts/partials/sidebar/cli.html
+++ b/themes/geekboot/layouts/partials/sidebar/cli.html
@@ -1,6 +1,6 @@
 <div class="section-container container pe-0 pt-1">
     <div class="nav-container">
-        <a href="{{.Site.BaseURL}}cli" class="d-inline-flex align-items-center">
+        <a href="{{.Site.BaseURL}}cli/" class="d-inline-flex align-items-center">
         Crossplane CLI Documentation
         </a>
     </div>

--- a/themes/geekboot/layouts/partials/sidebar/user-docs.html
+++ b/themes/geekboot/layouts/partials/sidebar/user-docs.html
@@ -1,7 +1,7 @@
 <div class="section-container container pe-0 pt-1">
     <div class="nav-container">
         <a href="{{.Site.BaseURL}}v{{.Site.Params.latest}}/" class="d-inline-flex align-items-center">
-        User Documentation
+        Crossplane Core Documentation
         </a>
     </div>
 </div>

--- a/themes/geekboot/layouts/partials/single-list.html
+++ b/themes/geekboot/layouts/partials/single-list.html
@@ -4,7 +4,7 @@
       <div class="offcanvas-header pb-4 border-bottom">
         <div class="d-flex offcanvas-title fw-bold" id="bdNavbarOffcanvasLabel">
           Crossplane Documentation -
-          {{- if $.Param "docs" -}}
+          {{- if (partial "utils/is-versioned" .) -}}
           {{ if ne .Page.Params.version "master" }} v{{ end}}{{.Page.Params.version}}
           {{- else }}
             {{.Page.Params.product }}
@@ -19,7 +19,7 @@
     <div class="bd-intro pt-2 ps-lg-2">
       <div class="d-md-flex flex-md-row-reverse align-items-center justify-content-between">
         <div class="mb-3 mb-md-0 d-flex">
-          {{ if $.Param "docs" }}
+          {{ if (partial "utils/is-versioned" .) }}
             {{ partial "version-dropdown-menu" . }}
           {{ end }}
         </div>
@@ -67,15 +67,25 @@
     {{ end }}
 
       <div class="bd-content ps-lg-2 DocSearch-content">
-        {{ if $.Param "docs" }}
-          {{ $pageVer := .Page.Params.version | default .Site.Params.latest }}
+        {{ if (partial "utils/is-versioned" .) }}
+          {{/* Per-track "latest" and product name so the alerts read correctly
+               for both core Crossplane and the CLI track. */}}
+          {{ $track := .Page.Params.track | default "core" }}
+          {{ $latest := .Site.Params.latest }}
+          {{ $productName := "Crossplane" }}
+          {{ if eq $track "cli" }}
+            {{ $latest = .Site.Params.cliLatest }}
+            {{ $productName = "Crossplane CLI" }}
+          {{ end }}
+          {{ $pageVer := .Page.Params.version | default $latest }}
+          {{ $alertCtx := dict "page" . "latest" $latest "productName" $productName }}
 
           {{- if eq .Page.Params.version "master" -}}
-            {{ partialCached "master-version-alert" . }}
+            {{ partial "master-version-alert" $alertCtx }}
           {{- else if strings.HasSuffix $pageVer "-preview" -}}
-            {{ partialCached "preview-version-alert" . .Section }}
-          {{- else if ne $pageVer .Site.Params.latest -}}
-            {{ partialCached "old-version-alert" . .Section }}
+            {{ partial "preview-version-alert" $alertCtx }}
+          {{- else if ne $pageVer $latest -}}
+            {{ partial "old-version-alert" $alertCtx }}
           {{ end }}
         {{ end }}
 

--- a/themes/geekboot/layouts/partials/utils/is-versioned.html
+++ b/themes/geekboot/layouts/partials/utils/is-versioned.html
@@ -1,0 +1,8 @@
+{{/* Reports whether a page belongs to a versioned docs track (core or CLI) as
+     opposed to unversioned content like the Contributing Guide. Unversioned
+     content uses the explicit "0" sentinel; everything else is versioned —
+     including the build-time /latest and /cli/latest copies, whose `version:`
+     line is stripped (empty), which still default to the track's latest.
+     Use this to gate version UI (the version selector, version alerts, the
+     versioned sidebar title) independently of the core-specific `docs` flag. */}}
+{{ return (ne .Page.Params.version "0") }}

--- a/themes/geekboot/layouts/partials/utils/sorted-versions.html
+++ b/themes/geekboot/layouts/partials/utils/sorted-versions.html
@@ -2,8 +2,18 @@
 {{ $majorlist := slice }}
 {{ $sorted_list := slice }}
 
+{{/*
+  Accepts either a bare Page (the core track, iterating top-level sections) or a
+  dict {page, sections} where "sections" is the list of version sections to sort
+  (e.g. the CLI track passes (.Site.GetPage "/cli").Sections).
+*/}}
+{{ $sections := .Site.Sections }}
+{{ if reflect.IsMap . }}
+    {{ $sections = .sections }}
+{{ end }}
+
 {{/* Collect all versions and parse semver for sorting */}}
-{{ range .Site.Sections }}
+{{ range $sections }}
     {{/* Skip versions marked as hidden */}}
     {{ if not .Page.Params.hidden }}
         {{ if eq .Page.Params.version "master" }}

--- a/themes/geekboot/layouts/partials/version-dropdown-menu.html
+++ b/themes/geekboot/layouts/partials/version-dropdown-menu.html
@@ -1,27 +1,53 @@
+{{/* Which versioned track is this page on? "core" (top-level v* sections) or
+     "cli" (subsections of /cli). The track determines which versions appear in
+     the dropdown, which "latest" badges them, and where the fallback section
+     pages live. */}}
+{{ $track := .Page.Params.track | default "core" }}
+{{ $latest := .Site.Params.latest }}
+{{ $sectionPrefix := "v" }}
+{{ $masterSection := "master" }}
 {{ $sorted_list := partial "utils/sorted-versions" . }}
-{{ $cur_ver := .Page.Params.version | default .Site.Params.latest }}
+{{ if eq $track "cli" }}
+    {{ $latest = .Site.Params.cliLatest }}
+    {{ $sectionPrefix = "/cli/v" }}
+    {{ $masterSection = "/cli/master" }}
+    {{ $sorted_list = partial "utils/sorted-versions" (dict "page" . "sections" (.Site.GetPage "/cli").Sections) }}
+{{ end }}
+{{ $cur_ver := .Page.Params.version | default $latest }}
 
 <div class="dropdown float-end bd-dropdown">
     <a class="btn btn-outline-secondary dropdown-toggle bd-dropdown-item text-reset" href="#" role="button" id="dropdownMenuLink" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
         {{ if ne .Page.Params.version "master" }}v{{ end }}{{ $cur_ver }}
-        {{ if eq $cur_ver .Site.Params.latest }}
+        {{ if eq $cur_ver $latest }}
         <div class="badge rounded-pill latest">Latest</div>
         {{ end }}
     </a>
 
     <div class="dropdown-menu bd-border-color bd-dropdown" aria-labelledby="dropdownMenuLink">
-        {{ $master_url := replaceRE "v[0-9].[0-9]" "master" .Permalink }}
         {{/*  Iterate over the ordered list of available versions. */}}
         {{ range $sorted_list }}
             {{ $matchingTitle := $.Title }}
             {{ if $.Params.matchTitle }}
                 {{ $matchingTitle = $.Params.matchTitle }}
             {{ end }}
-            {{/*  For a version, see if there is a page with an identical title to the page we're on. If not use the page at /content/v<version>  */}}
-            {{ $versionPage :=  index (where (where $.Site.Pages "Title" $matchingTitle) ".Page.Params.version" .) 0 | default ($.Site.GetPage (printf "v%s" .)) }}
+            {{/*  For a version, see if there is a page with an identical title to
+                  the page we're on, restricted to the current track so a CLI page
+                  can't match a same-titled core page. If none, fall back to the
+                  track's section index at /content/<prefix><version>. */}}
+            {{ $candidates := where (where $.Site.Pages "Title" $matchingTitle) ".Page.Params.version" . }}
+            {{/* Keep only candidates on the current track: CLI pages live under
+                 /cli/, core pages do not. */}}
+            {{ $tracked := slice }}
+            {{ range $candidates }}
+                {{ $isCli := hasPrefix .RelPermalink "/cli/" }}
+                {{ if eq (cond $isCli "cli" "core") $track }}
+                    {{ $tracked = $tracked | append . }}
+                {{ end }}
+            {{ end }}
+            {{ $versionPage := index $tracked 0 | default ($.Site.GetPage (printf "%s%s" $sectionPrefix .)) }}
             {{/*  If the version is master get the master page since "vmaster" doesn't exist  */}}
             {{ if not $versionPage }}
-                {{ $versionPage = $.Site.GetPage "master" }}
+                {{ $versionPage = $.Site.GetPage $masterSection }}
             {{ end }}
                 {{ with $versionPage }}
                     {{ $isLatest := false }}
@@ -33,12 +59,12 @@
                             master
                         {{ else }}
                             {{ if eq .Page.Params.version "" }}
-                                {{ (printf "v%s" .Site.Params.latest) }}
+                                {{ (printf "v%s" $latest) }}
                             {{ else }}
                                 {{ (printf "v%s" .Page.Params.version) }}
                             {{ end }}
                         {{ end }}
-                        {{ if or (eq .Page.Params.version .Site.Params.latest) (eq .Page.Params.version "") }}
+                        {{ if or (eq .Page.Params.version $latest) (eq .Page.Params.version "") }}
                         <div class="badge rounded-pill latest">Latest</div>
                         {{ end }}
                     </a>

--- a/utils/htmltest/.htmltest.yml
+++ b/utils/htmltest/.htmltest.yml
@@ -9,5 +9,4 @@ IgnoreURLs:
   - "www.googletagmanager.com/*" # Ignore google tag manager
   - "twitter.com/*" # Ignore twitter links since they send to login page
   - "https://releases.crossplane.io/stable/current/bin" # S3 bucket listing always returns 404 status even with directory listing
-  - "docs.crossplane.io/latest/*" # Allow links to the latest release (e.g. from knowledge-base)
   - "github.com/crossplane/docs/issues/new*" # Ignore the "open an issue" link


### PR DESCRIPTION
In the near future, the CLI version will diverge from the core Crossplane version (i.e., CLI v2.4 will be released before Crossplane v2.4). All the documentation is currently versioned together, which will be confusing or incorrect when the CLI version no longer matches the core version.

Move the CLI documentation into its own set of versioned directories, and update cross-links between the core and CLI documentation sets to be explicitly versioned. Give the CLI documentation its own sidebar, similar to the contributing guide, and its own version menu. Rename the "CLI Reference" page to "CLI Overview" so that it's a better section header. Update the sidebar to have a link to the CLI docs when browsing the core documentation, and a link back to the core docs when browsing the CLI docs; add an `<hr>` above these links to visually separate them from the regular TOC for the current section.
