### PR TITLE
Document the --repository flag for project init

### DIFF
--- a/content/cli/master/command-reference.md
+++ b/content/cli/master/command-reference.md
@@ -1228,6 +1228,7 @@ crossplane project init <name> [flags]
 | Short flag | Long flag | Description |
 |------------|-----------|-------------|
 | `-d` | `--directory=STRING` | Directory to initialize. Defaults to project name. |
+| `-r` | `--repository=STRING` | Repository name/path to use in the crossplane-project.yaml file.  Defaults to `example.com/my-org` |
 {{< /table >}}
 
 

--- a/content/cli/v2.3/command-reference.md
+++ b/content/cli/v2.3/command-reference.md
@@ -1228,6 +1228,7 @@ crossplane project init <name> [flags]
 | Short flag | Long flag | Description |
 |------------|-----------|-------------|
 | `-d` | `--directory=STRING` | Directory to initialize. Defaults to project name. |
+| `-r` | `--repository=STRING` | Repository name/path to use in the crossplane-project.yaml file.  Defaults to `example.com/my-org` |
 {{< /table >}}
 
 


### PR DESCRIPTION
Add documentation for the `--repository` flag for `crossplane project init`