### PR TITLE
docs: bump function-kro to v0.3.0 in get-started composition

### DIFF
--- a/content/master/get-started/get-started-with-composition.md
+++ b/content/master/get-started/get-started-with-composition.md
@@ -198,7 +198,7 @@ Check that Crossplane installed the function:
 ```shell {copy-lines="1"}
 kubectl get -f {{< manifest-url path="get-started/composition/fn-kro.yaml" >}}
 NAME                              INSTALLED   HEALTHY   PACKAGE                                                     AGE
-crossplane-contrib-function-kro   True        True      xpkg.crossplane.io/crossplane-contrib/function-kro:v0.1.0   6s
+crossplane-contrib-function-kro   True        True      xpkg.crossplane.io/crossplane-contrib/function-kro:v0.3.0   6s
 ```
 {{< /tab >}}
 

--- a/content/master/manifests/get-started/composition/composition-yaml-cel.yaml
+++ b/content/master/manifests/get-started/composition/composition-yaml-cel.yaml
@@ -12,7 +12,7 @@ spec:
     functionRef:
       name: crossplane-contrib-function-kro
     input:
-      apiVersion: kro.fn.crossplane.io/v1beta1
+      apiVersion: kro.fn.crossplane.io/v1alpha1
       kind: ResourceGraph
       status:
         replicas: ${deployment.status.?availableReplicas.orValue(0)}

--- a/content/master/manifests/get-started/composition/fn-kro.yaml
+++ b/content/master/manifests/get-started/composition/fn-kro.yaml
@@ -3,4 +3,4 @@ kind: Function
 metadata:
   name: crossplane-contrib-function-kro
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/function-kro:v0.1.0
+  package: xpkg.crossplane.io/crossplane-contrib/function-kro:v0.3.0

--- a/content/v2.2/get-started/get-started-with-composition.md
+++ b/content/v2.2/get-started/get-started-with-composition.md
@@ -199,7 +199,7 @@ Check that Crossplane installed the function:
 ```shell {copy-lines="1"}
 kubectl get -f {{< manifest-url path="get-started/composition/fn-kro.yaml" >}}
 NAME                              INSTALLED   HEALTHY   PACKAGE                                                     AGE
-crossplane-contrib-function-kro   True        True      xpkg.crossplane.io/crossplane-contrib/function-kro:v0.1.0   6s
+crossplane-contrib-function-kro   True        True      xpkg.crossplane.io/crossplane-contrib/function-kro:v0.3.0   6s
 ```
 {{< /tab >}}
 

--- a/content/v2.2/manifests/get-started/composition/composition-yaml-cel.yaml
+++ b/content/v2.2/manifests/get-started/composition/composition-yaml-cel.yaml
@@ -12,7 +12,7 @@ spec:
     functionRef:
       name: crossplane-contrib-function-kro
     input:
-      apiVersion: kro.fn.crossplane.io/v1beta1
+      apiVersion: kro.fn.crossplane.io/v1alpha1
       kind: ResourceGraph
       status:
         replicas: ${deployment.status.?availableReplicas.orValue(0)}

--- a/content/v2.2/manifests/get-started/composition/fn-kro.yaml
+++ b/content/v2.2/manifests/get-started/composition/fn-kro.yaml
@@ -3,4 +3,4 @@ kind: Function
 metadata:
   name: crossplane-contrib-function-kro
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/function-kro:v0.1.0
+  package: xpkg.crossplane.io/crossplane-contrib/function-kro:v0.3.0

--- a/content/v2.3/get-started/get-started-with-composition.md
+++ b/content/v2.3/get-started/get-started-with-composition.md
@@ -198,7 +198,7 @@ Check that Crossplane installed the function:
 ```shell {copy-lines="1"}
 kubectl get -f {{< manifest-url path="get-started/composition/fn-kro.yaml" >}}
 NAME                              INSTALLED   HEALTHY   PACKAGE                                                     AGE
-crossplane-contrib-function-kro   True        True      xpkg.crossplane.io/crossplane-contrib/function-kro:v0.1.0   6s
+crossplane-contrib-function-kro   True        True      xpkg.crossplane.io/crossplane-contrib/function-kro:v0.3.0   6s
 ```
 {{< /tab >}}
 

--- a/content/v2.3/manifests/get-started/composition/composition-yaml-cel.yaml
+++ b/content/v2.3/manifests/get-started/composition/composition-yaml-cel.yaml
@@ -12,7 +12,7 @@ spec:
     functionRef:
       name: crossplane-contrib-function-kro
     input:
-      apiVersion: kro.fn.crossplane.io/v1beta1
+      apiVersion: kro.fn.crossplane.io/v1alpha1
       kind: ResourceGraph
       status:
         replicas: ${deployment.status.?availableReplicas.orValue(0)}

--- a/content/v2.3/manifests/get-started/composition/fn-kro.yaml
+++ b/content/v2.3/manifests/get-started/composition/fn-kro.yaml
@@ -3,4 +3,4 @@ kind: Function
 metadata:
   name: crossplane-contrib-function-kro
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/function-kro:v0.1.0
+  package: xpkg.crossplane.io/crossplane-contrib/function-kro:v0.3.0


### PR DESCRIPTION
The YAML+CEL get-started composition aggregates a Deployment's `availableReplicas` into an integer `status.replicas`, which never resolved before function-kro v0.3.0. [v0.3.0](https://github.com/crossplane-contrib/function-kro/releases/tag/v0.3.0) fixes integer-typed observed fields ([#68](https://github.com/crossplane-contrib/function-kro/pull/68)), so the example now populates `status.replicas` correctly.

This bumps the YAML+CEL examples to v0.3.0 across the `master`, `v2.2`, and `v2.3` docs, including the input `apiVersion` that v0.3.0 moved to `kro.fn.crossplane.io/v1alpha1`.

Verified end-to-end on a fresh kind cluster (Crossplane v2.3.2 + function-kro v0.3.0): the `App` XR reached `READY=True`, the composed Deployment and Service came up, and `status.replicas` resolved to the integer `2`.