### PR TITLE
docs(cli): add DevEx section to CLI overview

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the docs repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2

--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the docs repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get changed files
         id: changed-files

--- a/.github/workflows/weekly-link-checker.yml
+++ b/.github/workflows/weekly-link-checker.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the docs repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2

--- a/content/cli/master/_index.md
+++ b/content/cli/master/_index.md
@@ -12,11 +12,24 @@ Crossplane.
 The Crossplane CLI includes commands for:
 
 * building, installing, updating and pushing Crossplane Packages
-* building platforms using Crossplane Projects
+* building platforms using [Crossplane Projects]({{<ref "get-started/get-started-with-control-plane-projects">}})
 * testing and rendering standalone Composition Functions without the need to
   access a Kubernetes cluster running Crossplane
 * troubleshooting Crossplane Compositions, Composite Resources and Managed
   Resources
+
+## Crossplane Projects (DevEx)
+
+The Crossplane CLI includes a suite of developer experience commands for
+building, testing, and managing Crossplane Projects. Use `crossplane project
+init` to scaffold a new project, `crossplane xrd generate` and `crossplane
+composition generate` to create API definitions and compositions, and
+`crossplane function generate` to add composition functions in Go, Python,
+KCL, or templated YAML.
+
+See the [Get Started with Control Plane Projects]({{<ref
+"get-started/get-started-with-control-plane-projects">}}) guide for a complete
+tutorial.
 
 ## Installing the CLI
 


### PR DESCRIPTION
Closes #1124

## Summary

Crossplane DevEx was updated in crossplane/cli#10. This change adds a
dedicated DevEx section to the CLI overview page linking to the Control
Plane Projects getting started guide, and adds cross-references from the
features list to the guide.

## How to Test
Review the updated CLI overview page. The DevEx section links to the existing
getting started guide.