### PR TITLE
docs: replace stale feature flag install example

### DIFF
--- a/content/master/get-started/install.md
+++ b/content/master/get-started/install.md
@@ -122,7 +122,7 @@ at the table below.
 
 Set these flags either in the `values.yaml` file or at install time using the
 `--set` flag, for example: `--set
-args='{"--enable-composition-functions","--enable-composition-webhook-schema-validation"}'`.
+args='{"--enable-operations","--enable-signature-verification"}'`.
 
 ## Install pre-release Crossplane versions
 

--- a/content/v2.2/get-started/install.md
+++ b/content/v2.2/get-started/install.md
@@ -121,7 +121,7 @@ at the table below.
 
 Set these flags either in the `values.yaml` file or at install time using the
 `--set` flag, for example: `--set
-args='{"--enable-composition-functions","--enable-composition-webhook-schema-validation"}'`.
+args='{"--enable-operations","--enable-signature-verification"}'`.
 
 ## Install pre-release Crossplane versions
 

--- a/content/v2.3/get-started/install.md
+++ b/content/v2.3/get-started/install.md
@@ -122,7 +122,7 @@ at the table below.
 
 Set these flags either in the `values.yaml` file or at install time using the
 `--set` flag, for example: `--set
-args='{"--enable-composition-functions","--enable-composition-webhook-schema-validation"}'`.
+args='{"--enable-operations","--enable-signature-verification"}'`.
 
 ## Install pre-release Crossplane versions
 

--- a/content/v2.4/get-started/install.md
+++ b/content/v2.4/get-started/install.md
@@ -122,7 +122,7 @@ at the table below.
 
 Set these flags either in the `values.yaml` file or at install time using the
 `--set` flag, for example: `--set
-args='{"--enable-composition-functions","--enable-composition-webhook-schema-validation"}'`.
+args='{"--enable-operations","--enable-signature-verification"}'`.
 
 ## Install pre-release Crossplane versions
 


### PR DESCRIPTION
## Summary
- The get-started install pages still used removed flags (`--enable-composition-functions`, `--enable-composition-webhook-schema-validation`) in the Helm `--set args` example.
- Those flags break installs on current Crossplane (see #1098). The feature-flag table on the same pages is already correct.
- Example now uses current alpha flags from that table: `--enable-operations` and `--enable-signature-verification`.
- Updated `master`, `v2.3`, `v2.2`, and `v2.1` install pages. Left `v1.20` alone (those flags still appear in that version's table).

## Test plan
- [x] Confirm example flags exist in the same page feature-flag tables
- [ ] Spot-check rendered pages after merge

Fixes #1098
