### PR TITLE
docs(release): update release template to include step to update Algolia crawler pathsToMatch

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_release.md
+++ b/.github/ISSUE_TEMPLATE/new_release.md
@@ -12,4 +12,5 @@ labels: release
 - [ ] Update `version` in the `_index.md` file of `/content/<new latest>` from `master` to the correct version.
 - [ ] Create a [new release/tag](https://github.com/crossplane/docs/releases/new) named `v<EOL version>-archive` to snapshot EOL'd docs.
 - [ ] Remove EOL'd docs version from "/content" directory and run `hugo` locally to check for broken links.
+- [ ] Update `pathsToMatch` in the Algolia crawler [config](https://crawler.algolia.com/admin/crawlers/b1863584-45fc-4117-831f-8d68e47b2e72/configuration/edit) to add the new version and remove the EOL version.
 - [ ] Trigger [Algolia Crawler](https://crawler.algolia.com/) after publishing to reindex results.


### PR DESCRIPTION
This PR adds one new step to the release checklist template, to ensure the release process updates the Algolia crawler configuration with the new version being released, and removes the old EOL version.

Fixes https://github.com/crossplane/docs/issues/1096