### PR TITLE
docs: drop v1 X-prefix kind recommendation from XRD docs

### DIFF
--- a/content/master/composition/composite-resource-definitions.md
+++ b/content/master/composition/composite-resource-definitions.md
@@ -62,7 +62,7 @@ spec:
   scope: Namespaced
   group: example.org
   names:
-    kind: XMyDatabase
+    kind: MyDatabase
     plural: mydatabases
   versions:
   - name: v1alpha1
@@ -119,8 +119,8 @@ The required name fields are:
 
 * `kind` - the `kind` value to use when calling this API. The kind is
   [UpperCamelCased](https://kubernetes.io/docs/contribute/style/style-guide/#use-upper-camel-case-for-api-objects).
-  Crossplane recommends starting XRD `kinds` with an `X` to show
-  it's a custom Crossplane API definition.
+  An `X` prefix isn't required. That convention distinguished claims
+  from composite resources in v1, and Crossplane v2 no longer uses claims.
 * `plural` - the plural name used for the API URL. The plural name must be
   lowercase.
 
@@ -144,7 +144,7 @@ metadata:
 spec:
   group: example.org
   names:
-    kind: XMyDatabase
+    kind: MyDatabase
     plural: mydatabases
     # Removed for brevity
 ```
@@ -210,12 +210,12 @@ is a {{<hover label="schema" line="20">}}string{{</hover>}}.
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition
 metadata:
-  name: xdatabases.custom-api.example.org
+  name: mydatabases.custom-api.example.org
 spec:
   group: custom-api.example.org
   names:
-    kind: xDatabase
-    plural: xdatabases
+    kind: MyDatabase
+    plural: mydatabases
   versions:
   - name: v1alpha1
     schema:
@@ -238,7 +238,7 @@ A composite resource using this API references the
 
 ```yaml {label="xr"}
 apiVersion: custom-api.example.org/v1alpha1
-kind: xDatabase
+kind: MyDatabase
 metadata:
   name: my-composite-resource
 spec:
@@ -278,12 +278,12 @@ In this example the XRD requires
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition
 metadata:
-  name: xdatabases.custom-api.example.org
+  name: mydatabases.custom-api.example.org
 spec:
   group: custom-api.example.org
   names:
-    kind: xDatabase
-    plural: xdatabases
+    kind: MyDatabase
+    plural: mydatabases
   versions:
   - name: v1alpha1
     schema:
@@ -376,12 +376,12 @@ and
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition
 metadata:
-  name: xdatabases.custom-api.example.org
+  name: mydatabases.custom-api.example.org
 spec:
   group: custom-api.example.org
   names:
-    kind: xDatabase
-    plural: xdatabases
+    kind: MyDatabase
+    plural: mydatabases
   versions:
   - name: v1alpha1
     served: true
@@ -459,12 +459,12 @@ A second version,
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition
 metadata:
-  name: xdatabases.custom-api.example.org
+  name: mydatabases.custom-api.example.org
 spec:
   group: custom-api.example.org
   names:
-    kind: xDatabase
-    plural: xdatabases
+    kind: MyDatabase
+    plural: mydatabases
   versions:
   - name: v1alpha1
     schema:
@@ -558,7 +558,7 @@ to set the default Composition.
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition
 metadata:
-  name: xdatabases.custom-api.example.org
+  name: mydatabases.custom-api.example.org
 spec:
   defaultCompositionRef:
     name: myComposition
@@ -589,7 +589,7 @@ this XRD.
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition
 metadata:
-  name: xdatabases.custom-api.example.org
+  name: mydatabases.custom-api.example.org
 spec:
   defaultCompositionUpdatePolicy: Manual
   group: custom-api.example.org
@@ -615,7 +615,7 @@ set
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition
 metadata:
-  name: xdatabases.custom-api.example.org
+  name: mydatabases.custom-api.example.org
 spec:
   enforcedCompositionRef:
     name: myComposition
@@ -638,7 +638,7 @@ Verify an XRD with `kubectl get compositeresourcedefinition` or the short form,
 ```yaml {label="getxrd",copy-lines="1"}
 kubectl get xrd
 NAME                                ESTABLISHED   OFFERED   AGE
-xdatabases.custom-api.example.org   True          True      22m
+mydatabases.custom-api.example.org  True          True      22m
 ```
 
 The `ESTABLISHED` field indicates Crossplane installed the Kubernetes custom

--- a/content/v2.1/composition/composite-resource-definitions.md
+++ b/content/v2.1/composition/composite-resource-definitions.md
@@ -62,7 +62,7 @@ spec:
   scope: Namespaced
   group: example.org
   names:
-    kind: XMyDatabase
+    kind: MyDatabase
     plural: mydatabases
   versions:
   - name: v1alpha1
@@ -119,8 +119,8 @@ The required name fields are:
 
 * `kind` - the `kind` value to use when calling this API. The kind is
   [UpperCamelCased](https://kubernetes.io/docs/contribute/style/style-guide/#use-upper-camel-case-for-api-objects).
-  Crossplane recommends starting XRD `kinds` with an `X` to show
-  it's a custom Crossplane API definition.
+  An `X` prefix isn't required. That convention distinguished claims
+  from composite resources in v1, and Crossplane v2 no longer uses claims.
 * `plural` - the plural name used for the API URL. The plural name must be
   lowercase.
 
@@ -130,9 +130,8 @@ The XRD
 {{<hover label="xrdName" line="9">}}plural{{</hover>}} name, `.` (dot character),
 {{<hover label="xrdName" line="6">}}group{{</hover>}}.
 
-For example, {{<hover label="xrdName"
-line="4">}}mydatabases.example.org{{</hover>}} matches the {{<hover
-label="xrdName" line="9">}}plural{{</hover>}} name
+For example, {{<hover label="xrdName" line="4">}}mydatabases.example.org{{</hover>}} matches the
+{{<hover label="xrdName" line="9">}}plural{{</hover>}} name
 {{<hover label="xrdName" line="9">}}mydatabases{{</hover>}}, `.`
 {{<hover label="xrdName" line="6">}}group{{</hover>}} name,
 {{<hover label="xrdName" line="6">}}example.org{{</hover>}}.
@@ -145,7 +144,7 @@ metadata:
 spec:
   group: example.org
   names:
-    kind: XMyDatabase
+    kind: MyDatabase
     plural: mydatabases
     # Removed for brevity
 ```
@@ -211,12 +210,12 @@ is a {{<hover label="schema" line="20">}}string{{</hover>}}.
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition
 metadata:
-  name: xdatabases.custom-api.example.org
+  name: mydatabases.custom-api.example.org
 spec:
   group: custom-api.example.org
   names:
-    kind: xDatabase
-    plural: xdatabases
+    kind: MyDatabase
+    plural: mydatabases
   versions:
   - name: v1alpha1
     schema:
@@ -239,7 +238,7 @@ A composite resource using this API references the
 
 ```yaml {label="xr"}
 apiVersion: custom-api.example.org/v1alpha1
-kind: xDatabase
+kind: MyDatabase
 metadata:
   name: my-composite-resource
 spec:
@@ -279,12 +278,12 @@ In this example the XRD requires
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition
 metadata:
-  name: xdatabases.custom-api.example.org
+  name: mydatabases.custom-api.example.org
 spec:
   group: custom-api.example.org
   names:
-    kind: xDatabase
-    plural: xdatabases
+    kind: MyDatabase
+    plural: mydatabases
   versions:
   - name: v1alpha1
     schema:
@@ -377,12 +376,12 @@ and
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition
 metadata:
-  name: xdatabases.custom-api.example.org
+  name: mydatabases.custom-api.example.org
 spec:
   group: custom-api.example.org
   names:
-    kind: xDatabase
-    plural: xdatabases
+    kind: MyDatabase
+    plural: mydatabases
   versions:
   - name: v1alpha1
     served: true
@@ -460,12 +459,12 @@ A second version,
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition
 metadata:
-  name: xdatabases.custom-api.example.org
+  name: mydatabases.custom-api.example.org
 spec:
   group: custom-api.example.org
   names:
-    kind: xDatabase
-    plural: xdatabases
+    kind: MyDatabase
+    plural: mydatabases
   versions:
   - name: v1alpha1
     schema:
@@ -552,7 +551,7 @@ to set the default Composition.
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition
 metadata:
-  name: xdatabases.custom-api.example.org
+  name: mydatabases.custom-api.example.org
 spec:
   defaultCompositionRef:
     name: myComposition
@@ -583,7 +582,7 @@ this XRD.
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition
 metadata:
-  name: xdatabases.custom-api.example.org
+  name: mydatabases.custom-api.example.org
 spec:
   defaultCompositionUpdatePolicy: Manual
   group: custom-api.example.org
@@ -609,7 +608,7 @@ set
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition
 metadata:
-  name: xdatabases.custom-api.example.org
+  name: mydatabases.custom-api.example.org
 spec:
   enforcedCompositionRef:
     name: myComposition
@@ -632,7 +631,7 @@ Verify an XRD with `kubectl get compositeresourcedefinition` or the short form,
 ```yaml {label="getxrd",copy-lines="1"}
 kubectl get xrd
 NAME                                ESTABLISHED   OFFERED   AGE
-xdatabases.custom-api.example.org   True          True      22m
+mydatabases.custom-api.example.org  True          True      22m
 ```
 
 The `ESTABLISHED` field indicates Crossplane installed the Kubernetes custom

--- a/content/v2.2/composition/composite-resource-definitions.md
+++ b/content/v2.2/composition/composite-resource-definitions.md
@@ -62,7 +62,7 @@ spec:
   scope: Namespaced
   group: example.org
   names:
-    kind: XMyDatabase
+    kind: MyDatabase
     plural: mydatabases
   versions:
   - name: v1alpha1
@@ -119,8 +119,8 @@ The required name fields are:
 
 * `kind` - the `kind` value to use when calling this API. The kind is
   [UpperCamelCased](https://kubernetes.io/docs/contribute/style/style-guide/#use-upper-camel-case-for-api-objects).
-  Crossplane recommends starting XRD `kinds` with an `X` to show
-  it's a custom Crossplane API definition.
+  An `X` prefix isn't required. That convention distinguished claims
+  from composite resources in v1, and Crossplane v2 no longer uses claims.
 * `plural` - the plural name used for the API URL. The plural name must be
   lowercase.
 
@@ -130,9 +130,8 @@ The XRD
 {{<hover label="xrdName" line="9">}}plural{{</hover>}} name, `.` (dot character),
 {{<hover label="xrdName" line="6">}}group{{</hover>}}.
 
-For example, {{<hover label="xrdName"
-line="4">}}mydatabases.example.org{{</hover>}} matches the {{<hover
-label="xrdName" line="9">}}plural{{</hover>}} name
+For example, {{<hover label="xrdName" line="4">}}mydatabases.example.org{{</hover>}} matches the
+{{<hover label="xrdName" line="9">}}plural{{</hover>}} name
 {{<hover label="xrdName" line="9">}}mydatabases{{</hover>}}, `.`
 {{<hover label="xrdName" line="6">}}group{{</hover>}} name,
 {{<hover label="xrdName" line="6">}}example.org{{</hover>}}.
@@ -145,7 +144,7 @@ metadata:
 spec:
   group: example.org
   names:
-    kind: XMyDatabase
+    kind: MyDatabase
     plural: mydatabases
     # Removed for brevity
 ```
@@ -211,12 +210,12 @@ is a {{<hover label="schema" line="20">}}string{{</hover>}}.
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition
 metadata:
-  name: xdatabases.custom-api.example.org
+  name: mydatabases.custom-api.example.org
 spec:
   group: custom-api.example.org
   names:
-    kind: xDatabase
-    plural: xdatabases
+    kind: MyDatabase
+    plural: mydatabases
   versions:
   - name: v1alpha1
     schema:
@@ -239,7 +238,7 @@ A composite resource using this API references the
 
 ```yaml {label="xr"}
 apiVersion: custom-api.example.org/v1alpha1
-kind: xDatabase
+kind: MyDatabase
 metadata:
   name: my-composite-resource
 spec:
@@ -279,12 +278,12 @@ In this example the XRD requires
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition
 metadata:
-  name: xdatabases.custom-api.example.org
+  name: mydatabases.custom-api.example.org
 spec:
   group: custom-api.example.org
   names:
-    kind: xDatabase
-    plural: xdatabases
+    kind: MyDatabase
+    plural: mydatabases
   versions:
   - name: v1alpha1
     schema:
@@ -377,12 +376,12 @@ and
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition
 metadata:
-  name: xdatabases.custom-api.example.org
+  name: mydatabases.custom-api.example.org
 spec:
   group: custom-api.example.org
   names:
-    kind: xDatabase
-    plural: xdatabases
+    kind: MyDatabase
+    plural: mydatabases
   versions:
   - name: v1alpha1
     served: true
@@ -460,12 +459,12 @@ A second version,
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition
 metadata:
-  name: xdatabases.custom-api.example.org
+  name: mydatabases.custom-api.example.org
 spec:
   group: custom-api.example.org
   names:
-    kind: xDatabase
-    plural: xdatabases
+    kind: MyDatabase
+    plural: mydatabases
   versions:
   - name: v1alpha1
     schema:
@@ -552,7 +551,7 @@ to set the default Composition.
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition
 metadata:
-  name: xdatabases.custom-api.example.org
+  name: mydatabases.custom-api.example.org
 spec:
   defaultCompositionRef:
     name: myComposition
@@ -583,7 +582,7 @@ this XRD.
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition
 metadata:
-  name: xdatabases.custom-api.example.org
+  name: mydatabases.custom-api.example.org
 spec:
   defaultCompositionUpdatePolicy: Manual
   group: custom-api.example.org
@@ -609,7 +608,7 @@ set
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition
 metadata:
-  name: xdatabases.custom-api.example.org
+  name: mydatabases.custom-api.example.org
 spec:
   enforcedCompositionRef:
     name: myComposition
@@ -632,7 +631,7 @@ Verify an XRD with `kubectl get compositeresourcedefinition` or the short form,
 ```yaml {label="getxrd",copy-lines="1"}
 kubectl get xrd
 NAME                                ESTABLISHED   OFFERED   AGE
-xdatabases.custom-api.example.org   True          True      22m
+mydatabases.custom-api.example.org  True          True      22m
 ```
 
 The `ESTABLISHED` field indicates Crossplane installed the Kubernetes custom

--- a/content/v2.3/composition/composite-resource-definitions.md
+++ b/content/v2.3/composition/composite-resource-definitions.md
@@ -62,7 +62,7 @@ spec:
   scope: Namespaced
   group: example.org
   names:
-    kind: XMyDatabase
+    kind: MyDatabase
     plural: mydatabases
   versions:
   - name: v1alpha1
@@ -119,8 +119,8 @@ The required name fields are:
 
 * `kind` - the `kind` value to use when calling this API. The kind is
   [UpperCamelCased](https://kubernetes.io/docs/contribute/style/style-guide/#use-upper-camel-case-for-api-objects).
-  Crossplane recommends starting XRD `kinds` with an `X` to show
-  it's a custom Crossplane API definition.
+  An `X` prefix isn't required. That convention distinguished claims
+  from composite resources in v1, and Crossplane v2 no longer uses claims.
 * `plural` - the plural name used for the API URL. The plural name must be
   lowercase.
 
@@ -144,7 +144,7 @@ metadata:
 spec:
   group: example.org
   names:
-    kind: XMyDatabase
+    kind: MyDatabase
     plural: mydatabases
     # Removed for brevity
 ```
@@ -210,12 +210,12 @@ is a {{<hover label="schema" line="20">}}string{{</hover>}}.
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition
 metadata:
-  name: xdatabases.custom-api.example.org
+  name: mydatabases.custom-api.example.org
 spec:
   group: custom-api.example.org
   names:
-    kind: xDatabase
-    plural: xdatabases
+    kind: MyDatabase
+    plural: mydatabases
   versions:
   - name: v1alpha1
     schema:
@@ -238,7 +238,7 @@ A composite resource using this API references the
 
 ```yaml {label="xr"}
 apiVersion: custom-api.example.org/v1alpha1
-kind: xDatabase
+kind: MyDatabase
 metadata:
   name: my-composite-resource
 spec:
@@ -278,12 +278,12 @@ In this example the XRD requires
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition
 metadata:
-  name: xdatabases.custom-api.example.org
+  name: mydatabases.custom-api.example.org
 spec:
   group: custom-api.example.org
   names:
-    kind: xDatabase
-    plural: xdatabases
+    kind: MyDatabase
+    plural: mydatabases
   versions:
   - name: v1alpha1
     schema:
@@ -376,12 +376,12 @@ and
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition
 metadata:
-  name: xdatabases.custom-api.example.org
+  name: mydatabases.custom-api.example.org
 spec:
   group: custom-api.example.org
   names:
-    kind: xDatabase
-    plural: xdatabases
+    kind: MyDatabase
+    plural: mydatabases
   versions:
   - name: v1alpha1
     served: true
@@ -459,12 +459,12 @@ A second version,
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition
 metadata:
-  name: xdatabases.custom-api.example.org
+  name: mydatabases.custom-api.example.org
 spec:
   group: custom-api.example.org
   names:
-    kind: xDatabase
-    plural: xdatabases
+    kind: MyDatabase
+    plural: mydatabases
   versions:
   - name: v1alpha1
     schema:
@@ -558,7 +558,7 @@ to set the default Composition.
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition
 metadata:
-  name: xdatabases.custom-api.example.org
+  name: mydatabases.custom-api.example.org
 spec:
   defaultCompositionRef:
     name: myComposition
@@ -589,7 +589,7 @@ this XRD.
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition
 metadata:
-  name: xdatabases.custom-api.example.org
+  name: mydatabases.custom-api.example.org
 spec:
   defaultCompositionUpdatePolicy: Manual
   group: custom-api.example.org
@@ -615,7 +615,7 @@ set
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition
 metadata:
-  name: xdatabases.custom-api.example.org
+  name: mydatabases.custom-api.example.org
 spec:
   enforcedCompositionRef:
     name: myComposition
@@ -638,7 +638,7 @@ Verify an XRD with `kubectl get compositeresourcedefinition` or the short form,
 ```yaml {label="getxrd",copy-lines="1"}
 kubectl get xrd
 NAME                                ESTABLISHED   OFFERED   AGE
-xdatabases.custom-api.example.org   True          True      22m
+mydatabases.custom-api.example.org  True          True      22m
 ```
 
 The `ESTABLISHED` field indicates Crossplane installed the Kubernetes custom


### PR DESCRIPTION
## Summary
- Fixes #1056: the v2 XRD page still recommended prefixing kinds with `X` (a v1 claim vs XR distinction) and used inconsistent examples (`XMyDatabase`, `xDatabase`, `xdatabases`).
- Updates `content/v2.1`, `content/v2.2`, `content/v2.3`, and `content/master` to match the rest of the v2 composition docs, which already use `MyDatabase` / `mydatabases`.
- Leaves v1.20 unchanged, since claims still exist there.
- Rejoins a split Hugo hover shortcode in v2.1/v2.2 so Vale does not spellcheck `mydatabases.example.org` (same fix as 28fbaa13 on later versions).

## Test plan
- [x] Vale 3.14.2 (`utils/vale/.vale.ini`) reports 0 issues on the four changed files
- [ ] Confirm the XRD names section on v2.1–v2.3 and latest no longer recommends an `X` prefix
- [ ] Confirm examples use `kind: MyDatabase` and `plural: mydatabases`
- [ ] Confirm v1 docs still document the `X` prefix for claims


Made with [Cursor](https://cursor.com)