### PR TITLE
fix(404): fix 404 link

### DIFF
--- a/content/v1.20/software/install.md
+++ b/content/v1.20/software/install.md
@@ -140,7 +140,7 @@ Apply customizations with the command line or with a Helm _values_ file.
 | `image.repository` | Repository for the Crossplane pod image. | `"xpkg.crossplane.io/crossplane/crossplane"` |
 | `image.tag` | The Crossplane image tag. Defaults to the value of `appVersion` in `Chart.yaml`. | `""` |
 | `imagePullSecrets` | The imagePullSecret names to add to the Crossplane ServiceAccount. | `[]` |
-| `leaderElection` | Enable [leader election](https://docs.crossplane.io/latest/concepts/pods/#leader-election) for the Crossplane pod. | `true` |
+| `leaderElection` | Enable [leader election](https://docs.crossplane.io/v1.20/concepts/pods/#leader-election) for the Crossplane pod. | `true` |
 | `metrics.enabled` | Enable Prometheus path, port and scrape annotations and expose port 8080 for both the Crossplane and RBAC Manager pods. | `false` |
 | `metrics.port` | The port the metrics server listens on. | `""` |
 | `nodeSelector` | Add `nodeSelectors` to the Crossplane pod deployment. | `{}` |
@@ -155,7 +155,7 @@ Apply customizations with the command line or with a Helm _values_ file.
 | `rbacManager.affinity` | Add `affinities` to the RBAC Manager pod deployment. | `{}` |
 | `rbacManager.args` | Add custom arguments to the RBAC Manager pod. | `[]` |
 | `rbacManager.deploy` | Deploy the RBAC Manager pod and its required roles. | `true` |
-| `rbacManager.leaderElection` | Enable [leader election](https://docs.crossplane.io/latest/concepts/pods/#leader-election) for the RBAC Manager pod. | `true` |
+| `rbacManager.leaderElection` | Enable [leader election](https://docs.crossplane.io/v1.20/concepts/pods/#leader-election) for the RBAC Manager pod. | `true` |
 | `rbacManager.nodeSelector` | Add `nodeSelectors` to the RBAC Manager pod deployment. | `{}` |
 | `rbacManager.replicas` | The number of RBAC Manager pod `replicas` to deploy. | `1` |
 | `rbacManager.revisionHistoryLimit` | The number of RBAC Manager ReplicaSets to keep. | `nil` |


### PR DESCRIPTION
<!--
Thanks for contributing to the docs! 

For information about local previews with Hugo read the contributing getting started guide:
https://docs.crossplane.io/contribute/contribute/

For information about Hugo's features like tabs and hint boxes read the styling features guide:
https://docs.crossplane.io/contribute/features/

For information on using Vale and testing locally read our Using Vale guide:
https://docs.crossplane.io/contribute/vale/

Need more help? Join the Crossplane Slack and ask in the #documentation channel.
https://slack.crossplane.io/
-->

during some algolia Cralwer changes i found that https://docs.crossplane.io/latest/concepts/pods/#leader-election is not available anymore - as we restructured the docs page with the v2 release - so lets use the v1.20 link instead

<img width="697" height="349" alt="image" src="https://github.com/user-attachments/assets/9325c74c-ff2a-44a5-891f-4b8b069e697b" />
