### PR TITLE
feat(search): restrict search results to the current track (CLI vs core docs)

### DIFF
--- a/themes/geekboot/layouts/partials/scripts.html
+++ b/themes/geekboot/layouts/partials/scripts.html
@@ -19,6 +19,13 @@
         {{ end }}
     {{ end }}
 
+    {{/* Which track is this page on? Records are tagged "cli" or "core" by the
+         crawler; everything that isn't the CLI track (core, knowledge base,
+         contributing guide) searches the "core" records. */}}
+    {{ $track := cond (eq (.Page.Params.track | default "core") "cli") "cli" "core" }}
+    {{ $trackLatest := cond (eq $track "cli") .Site.Params.cliLatest .Site.Params.latest }}
+    {{ $latestLink := cond (eq $track "cli") (printf "/cli/v%s/" .Site.Params.cliLatest) (printf "/v%s/" .Site.Params.latest) }}
+
     const docSearchInstance = docsearch({
         container: '#docSearch',
         appId: '9UXKYX61NK',
@@ -26,19 +33,19 @@
         apiKey: 'e07e181044d561f6a4cb7261931d980a',
         placeholder: 'Search the docs',
         searchParameters: {
-            attributesToRetrieve: ['hierarchy.lvl0', 'hierarchy.lvl1', 'hierarchy.lvl2', 'hierarchy.lvl3', 'hierarchy.lvl4', 'hierarchy.lvl5', 'hierarchy.lvl6', 'content', 'type', 'url', 'version']{{ if $cur_ver }},
-            facetFilters: [['version:{{ $cur_ver }}']]{{ end }}
+            attributesToRetrieve: ['hierarchy.lvl0', 'hierarchy.lvl1', 'hierarchy.lvl2', 'hierarchy.lvl3', 'hierarchy.lvl4', 'hierarchy.lvl5', 'hierarchy.lvl6', 'content', 'type', 'url', 'version'],
+            facetFilters: [['track:{{ $track }}']{{ if $cur_ver }}, ['version:{{ $cur_ver }}']{{ end }}]
         },
         transformItems(items) {
             // Add version warning banner and badges after DOM renders
             setTimeout(() => {
-                {{ if and $cur_ver (ne .Page.Params.version "master") (ne .Page.Params.version .Site.Params.latest) }}
+                {{ if and $cur_ver (ne .Page.Params.version "master") (ne .Page.Params.version $trackLatest) }}
                 // Add warning banner for old version
                 const dropdown = document.querySelector('.DocSearch-Dropdown-Container');
                 if (dropdown && !dropdown.hasAttribute('data-version-banner-added')) {
                     const banner = document.createElement('div');
                     banner.style.cssText = 'padding: 12px; margin: 0 0 12px 0; background: #fff3cd; color: #856404; border-left: 4px solid #ffc107; font-size: 0.875rem;';
-                    banner.innerHTML = '<strong>Searching in v{{ .Page.Params.version }}</strong><br>You are viewing an older version. Results are filtered to this version only. <a href="/v{{ .Site.Params.latest }}/" style="color: #856404; text-decoration: underline; font-weight: 600;">View v{{ .Site.Params.latest }}</a>';
+                    banner.innerHTML = '<strong>Searching in v{{ .Page.Params.version }}</strong><br>You are viewing an older version. Results are filtered to this version only. <a href="{{ $latestLink }}" style="color: #856404; text-decoration: underline; font-weight: 600;">View v{{ $trackLatest }}</a>';
                     dropdown.insertBefore(banner, dropdown.firstChild);
                     dropdown.setAttribute('data-version-banner-added', 'true');
                 }


### PR DESCRIPTION
<!--
Thanks for contributing to the docs! 

For information about local previews with Hugo read the contributing getting started guide:
https://docs.crossplane.io/contribute/contribute/

For information about Hugo's features like tabs and hint boxes read the styling features guide:
https://docs.crossplane.io/contribute/features/

For information on using Vale and testing locally read our Using Vale guide:
https://docs.crossplane.io/contribute/vale/

Need more help? Join the Crossplane Slack and ask in the #documentation channel.
https://slack.crossplane.io/
-->

Since 2.3 the CLI is versioned and released separately from Crossplane core, so the two tracks have diverged (CLI is at v2.5, core at v2.4). The `version` facet from #1051 can't tell them apart: core v2.4 and CLI v2.4 pages both index as `version:2.4`, so search results leaked across tracks.

- Add a `track` facet filter: CLI pages (`/cli/**`) filter on `track:cli`, everything else (core, knowledge base, contributing) on `track:core`, ANDed with the existing version filter.
- Fix the "older version" search banner on CLI pages: it compared against the core `latest` (2.4), so CLI v2.5 pages wrongly showed it. It now uses `cliLatest` and links to `/cli/v2.5/`.

Algolia is already configured: the crawler tags records with `track`, a full recrawl has run, and `filterOnly(track)` is set on the index.


Check after the Crawl the track field is available:
<img width="691" height="338" alt="Screenshot 2026-08-25 at 16 52 54" src="https://github.com/user-attachments/assets/b2c6797d-6a43-4b7d-aeb0-0ce54e157963" />

Check on CLI Page Search:
<img width="628" height="640" alt="image" src="https://github.com/user-attachments/assets/3c18b2ba-f7c2-4844-8357-1f382a011093" />

Check that the Track FacetFilter is set during Search:
<img width="1412" height="616" alt="Screenshot 2026-08-25 at 16 53 59" src="https://github.com/user-attachments/assets/0cfce31e-4996-484a-939c-5f36e2308f22" />

<img width="1338" height="508" alt="image" src="https://github.com/user-attachments/assets/31831fd3-209f-43e0-b7be-8575f469979b" />

