### PR TITLE
fix(hugo): replace config keys and template vars deprecated in Hugo v0.153–v0.158

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: '0.147.3'
+          hugo-version: '0.162.1'
           extended: true
 
       - name: Build

--- a/.github/workflows/weekly-link-checker.yml
+++ b/.github/workflows/weekly-link-checker.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: '0.147.3'
+          hugo-version: '0.162.1'
           extended: true
 
       - name: Build

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 baseURL: "/"
 enableRobotsTXT: True
-languageCode: "en-us"
+locale: "en-us"
 title: "Crossplane"
 
 # directory name in /themes
@@ -69,18 +69,18 @@ module:
     target: assets
   - source: content
     target: assets/content
-    includeFiles:
+    files:
       - "**/**.png"
       - "**/**.jpg"
       - "**/**.jpeg"
       - "**/**.gif"
   - source: content
     target: data/crds/
-    includeFiles:
+    files:
       - "**/api/**.yaml"
   - source: content
     target: static
-    includeFiles:
+    files:
       - "**/manifests/**.yaml"
 
 # Give Hugo access to environmental variables matching a given regex.
@@ -90,6 +90,13 @@ security:
     getenv:
       - ^CONTEXT
       - ^REVIEW_ID
+  # Hugo >= 0.161 runs Node tools under the Node.js permission model, which
+  # blocks loading native addons unless the tool is allowlisted. PostCSS needs
+  # this to load the lightningcss native binary.
+  node:
+    permissions:
+      allowAddons:
+        - postcss
 
 # Global parameters accessible by any Page
 params:

--- a/netlify.toml
+++ b/netlify.toml
@@ -14,9 +14,12 @@
     publish = "public/"
     command = "bash netlify_build.sh"
 
-# The version of Hugo to use for the Netlify build.
+# The versions of Hugo and Node to use for the Netlify build.
+# Hugo >= 0.158 runs PostCSS under Node's permission model (node --permission),
+# which requires Node >= 22.13.
 [build.environment]
-  HUGO_VERSION = "0.147.3"
+  HUGO_VERSION = "0.162.1"
+  NODE_VERSION = "22"
 
 #
 # The following are Netlify redirects for moved docs pages

--- a/themes/geekboot/layouts/_default/section.rss.xml
+++ b/themes/geekboot/layouts/_default/section.rss.xml
@@ -21,7 +21,7 @@
     <link>{{ .Permalink }}</link>
     <description>Recent content {{ if ne .Title .Site.Title }}{{ with .Title }}in {{ . }} {{ end }}{{ end }}on {{ .Site.Title }}</description>
     <generator>Hugo -- gohugo.io</generator>
-    <language>{{ site.Language.LanguageCode }}</language>
+    <language>{{ site.Language.Locale }}</language>
     <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>
     {{- with .OutputFormats.Get "RSS" }}
     {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}

--- a/themes/geekboot/layouts/partials/crds.html
+++ b/themes/geekboot/layouts/partials/crds.html
@@ -5,10 +5,10 @@
     {{ partialCached "apiBuilder/GKVHeader" . }}
 
     <div id="crd-rows-container">
-        {{/* $.Site.Data is from the hugo config file module.mounts.target. */}}
+        {{/* hugo.Data is from the hugo config file module.mounts.target. */}}
         {{/* Hugo requires YAML to be in the 'data' location for processing */}}
         {{/* https://gohugo.io/methods/site/data/ */}}
-        {{ $crdFiles := index $.Site.Data.crds .Section "api" "crds" }}
+        {{ $crdFiles := index hugo.Data.crds .Section "api" "crds" }}
 
 
         {{/* Iterate over each CRD file */}}

--- a/themes/geekboot/layouts/partials/scripts.html
+++ b/themes/geekboot/layouts/partials/scripts.html
@@ -1,6 +1,6 @@
-{{ $js := resources.Get (index (index .Site.Data.assets "main.js") "src" | relURL) }}
+{{ $js := resources.Get (index (index hugo.Data.assets "main.js") "src" | relURL) }}
 <script src="{{ $js.Permalink }}" data-no-instant></script>
-{{- $jsmap := resources.Get (printf "%s.map" (index (index .Site.Data.assets "main.js") "src")) -}}
+{{- $jsmap := resources.Get (printf "%s.map" (index (index hugo.Data.assets "main.js") "src")) -}}
 {{- $jsmap.Publish -}}
 
 {{ if eq hugo.Environment "production" -}}

--- a/themes/geekboot/layouts/shortcodes/placeholder.html
+++ b/themes/geekboot/layouts/shortcodes/placeholder.html
@@ -12,7 +12,7 @@
     * markup: If it should render `svg` or `img` tags - default: "svg"
 */ -}}
 
-{{- $grays := $.Site.Data.grays -}}
+{{- $grays := hugo.Data.grays -}}
 {{- $default_color := (index $grays 2).hex -}}
 {{- $default_background := (index $grays 5).hex -}}
 

--- a/themes/geekboot/layouts/shortcodes/propertylist.html
+++ b/themes/geekboot/layouts/shortcodes/propertylist.html
@@ -1,8 +1,8 @@
 {{- $name := .Get "name" -}}
 
-{{- if .Site.Data.properties }}
+{{- if hugo.Data.properties }}
   <dl class="gdoc-props">
-    {{- with (index .Site.Data.properties (split $name ".")) }}
+    {{- with (index hugo.Data.properties (split $name ".")) }}
       {{- range $key, $value := .properties }}
         <dt class="flex flex-wrap align-center gdoc-props__meta">
           <span class="gdoc-props__title">{{ $key }}</span>


### PR DESCRIPTION
<!--
Thanks for contributing to the docs! 

For information about local previews with Hugo read the contributing getting started guide:
https://docs.crossplane.io/contribute/contribute/

For information about Hugo's features like tabs and hint boxes read the styling features guide:
https://docs.crossplane.io/contribute/features/

For information on using Vale and testing locally read our Using Vale guide:
https://docs.crossplane.io/contribute/vale/

Need more help? Join the Crossplane Slack and ask in the #documentation channel.
https://slack.crossplane.io/
-->
Fixes four deprecation warnings emitted by recent Hugo versions:

- `languageCode` → `locale` in config.yaml (deprecated in Hugo v0.158.0)
- `module.mounts.includeFiles` → `files` for the three content mounts in config.yaml (deprecated in Hugo v0.153.0), same glob patterns
- `.Site.Data` → `hugo.Data` in the geekboot theme shortcodes and partials (deprecated in Hugo v0.156.0)
- `site.Language.LanguageCode` → `site.Language.Locale` in the RSS template (deprecated in Hugo v0.158.0)
- bump hugo
- update security config for postcss config
- need to use node22

No content or rendering changes. Verified with a full `hugo` build at `--logLevel warn`, which now completes with zero warnings.



Fixes: #1137