### PR TITLE
ci: sync Algolia crawler config with published doc versions

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_release.md
+++ b/.github/ISSUE_TEMPLATE/new_release.md
@@ -12,5 +12,4 @@ labels: release
 - [ ] Update `version` in the `_index.md` file of `/content/<new latest>` from `master` to the correct version.
 - [ ] Create a [new release/tag](https://github.com/crossplane/docs/releases/new) named `v<EOL version>-archive` to snapshot EOL'd docs.
 - [ ] Remove EOL'd docs version from "/content" directory and run `hugo` locally to check for broken links.
-- [ ] Update `pathsToMatch` in the Algolia crawler [config](https://crawler.algolia.com/admin/crawlers/b1863584-45fc-4117-831f-8d68e47b2e72/configuration/edit) to add the new version and remove the EOL version.
-- [ ] Trigger [Algolia Crawler](https://crawler.algolia.com/) after publishing to reindex results with the new version.
+- [ ] After the site is published, run the [Sync Docs Search](https://github.com/crossplane/docs/actions/workflows/promote.yml) workflow. It syncs the Algolia crawler `pathsToMatch` with the version folders under `/content` (adds the new version, removes the EOL version) and triggers a reindex. Use `dry-run` first to review the change.

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,0 +1,129 @@
+name: Sync Docs Search
+
+on:
+  workflow_dispatch:
+    inputs:
+      reindex:
+        description: 'Trigger a full reindex afterwards'
+        type: boolean
+        default: true
+      dry-run:
+        description: 'Resolve and print the patch without pushing'
+        type: boolean
+        default: false
+  workflow_call:
+    inputs:
+      reindex: { type: boolean, required: false, default: true }
+      dry-run: { type: boolean, required: false, default: false }
+    secrets:
+      ALGOLIA_CRAWLER_USER_ID: { required: true }
+      ALGOLIA_CRAWLER_API_KEY: { required: true }
+      ALGOLIA_CRAWLER_ID:      { required: true }
+
+permissions:
+  contents: read
+
+# the config update is read-modify-write — never run two at once
+concurrency:
+  group: docs-search-config
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    env:
+      CRAWLER: https://crawler.algolia.com/api/1/crawlers
+      ID: ${{ secrets.ALGOLIA_CRAWLER_ID }}
+      AUTH: ${{ secrets.ALGOLIA_CRAWLER_USER_ID }}:${{ secrets.ALGOLIA_CRAWLER_API_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve versions from content folders
+        run: |
+          set -euo pipefail
+          core=$(find content -mindepth 1 -maxdepth 1 -type d -name 'v[0-9]*' -printf '%f\n' | sort -V)
+          cli=$(find content/cli -mindepth 1 -maxdepth 1 -type d -name 'v[0-9]*' -printf '%f\n' | sort -V)
+          [[ -n "$core" && -n "$cli" ]] || { echo "::error::no version folders under content/ — refusing to sync"; exit 1; }
+
+          # every version we are about to index must already be deployed
+          check() {  # $1 = url
+            code=$(curl -s -o /dev/null -w '%{http_code}' "$1")
+            [[ "$code" == "200" ]] || { echo "::error::$1 -> $code"; exit 1; }
+          }
+          for v in $core; do check "https://docs.crossplane.io/$v/"; done
+          for v in $cli;  do check "https://docs.crossplane.io/cli/$v/"; done
+
+          core_keep=$(printf '%s\n' $core | jq -R . | jq -cs .)
+          cli_keep=$(printf '%s\n' $cli | jq -R . | jq -cs .)
+          computed=$(jq -cn --argjson core "$core_keep" --argjson cli "$cli_keep" '
+            [($core[] | "https://docs.crossplane.io/\(.)/**"),
+             ($cli[]  | "https://docs.crossplane.io/cli/\(.)/**")]')
+
+          {
+            echo "CORE_KEEP=$core_keep"
+            echo "CLI_KEEP=$cli_keep"
+            echo "COMPUTED=$computed"
+          } >> "$GITHUB_ENV"
+          echo "Syncing: core=$core_keep cli=$cli_keep" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Build patch
+        run: |
+          set -euo pipefail
+          curl -sf -u "$AUTH" "$CRAWLER/$ID?withConfig=true" > current.json
+
+          jq -e '.config.actions | map(select(.name=="CrossplaneCrawler")) | length == 1' current.json >/dev/null \
+            || { echo "::error::action 'CrossplaneCrawler' not found in crawler config"; exit 1; }
+
+          # versioned patterns (vX.Y) are fully managed: replaced by the set
+          # computed from the content folders. everything else (latest, master,
+          # contribute, knowledge-base, negations) passes through untouched.
+          # negation patterns must stay at the end of pathsToMatch.
+          jq --argjson computed "$COMPUTED" --argjson core "$CORE_KEEP" --argjson cli "$CLI_KEEP" '
+            def versioned: test("^!?https://docs\\.crossplane\\.io/(cli/)?v[0-9]+\\.[0-9]+/");
+            def live:
+              if test("^!?https://docs\\.crossplane\\.io/cli/v")
+              then capture("/cli/(?<v>v[0-9]+\\.[0-9]+)/").v as $v | ($cli | index($v)) != null
+              else capture("\\.io/(?<v>v[0-9]+\\.[0-9]+)/").v as $v | ($core | index($v)) != null
+              end;
+            { actions: (.config.actions | map(
+                if .name == "CrossplaneCrawler" then
+                  .pathsToMatch |= (
+                    ((map(select((startswith("!") | not) and (versioned | not))) + $computed) | unique)
+                    + map(select(startswith("!") and ((versioned | not) or live)))
+                  )
+                else . end
+              ))
+            }
+          ' current.json > patch.json
+
+          jq -r '.config.actions[] | select(.name=="CrossplaneCrawler") | .pathsToMatch[]' current.json | sort > before.txt
+          jq -r '.actions[] | select(.name=="CrossplaneCrawler") | .pathsToMatch[]' patch.json | sort > after.txt
+
+          {
+            echo '### pathsToMatch after sync'
+            echo '```'
+            jq -r '.actions[] | select(.name=="CrossplaneCrawler") | .pathsToMatch[]' patch.json
+            echo '```'
+            if ! cmp -s before.txt after.txt; then
+              echo '### added'
+              echo '```'
+              comm -13 before.txt after.txt || true
+              echo '```'
+              echo '### removed'
+              echo '```'
+              comm -23 before.txt after.txt || true
+              echo '```'
+            else
+              echo '_no changes — crawler already in sync_'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Push config
+        if: ${{ !inputs.dry-run }}
+        run: |
+          curl -sf -X PATCH -u "$AUTH" -H 'Content-Type: application/json' \
+            --data-binary @patch.json "$CRAWLER/$ID/config"
+
+      - name: Reindex
+        if: ${{ inputs.reindex && !inputs.dry-run }}
+        run: curl -sf -X POST -u "$AUTH" "$CRAWLER/$ID/reindex"


### PR DESCRIPTION
<!--
Thanks for contributing to the docs! 

For information about local previews with Hugo read the contributing getting started guide:
https://docs.crossplane.io/contribute/contribute/

For information about Hugo's features like tabs and hint boxes read the styling features guide:
https://docs.crossplane.io/contribute/features/

For information on using Vale and testing locally read our Using Vale guide:
https://docs.crossplane.io/contribute/vale/

Need more help? Join the Crossplane Slack and ask in the #documentation channel.
https://slack.crossplane.io/
-->
The Algolia crawler config for docs.crossplane.io maintains an explicit pathsToMatch allow-list of the doc versions it should index. Today that list lives only in the Algolia dashboard and is edited by hand, so a version that ships without someone remembering to update it is crawled but never indexed under its own version facet, search for it silently returns nothing. The same applies in reverse: EOL'd versions linger in the config after their folders are removed.

This adds a workflow that makes the version folders under /content the single source of truth and syncs the crawler config to them:

Derives the version list from the content/v* and content/cli/v* folders, no version inputs needed, and core and CLI stay independent since each has its own folder set.
Confirms every derived version is actually live (HTTP 200 on /<version>/ and /cli/<version>/) before touching anything, and refuses to run if the folder list resolves empty.
GETs the current crawler config, replaces all versioned (vX.Y) pathsToMatch entries with the computed set — adding new versions and pruning EOL ones in the same pass and PATCHes it back. Non-versioned entries (latest, master, contribute, knowledge-base) pass through untouched, so the workflow doesn't need to know about them.
Optionally triggers a full reindex (needed after a release ;)).
Because the sync is idempotent (re-running against an in-sync config produces zero diff), it's safe to run on every release, the step summary shows the resulting list plus explicit added/removed sections, and a dry-run input prints the patch without pushing.

The Crawler API only accepts whole top-level properties, so this is a read-modify-write of the entire actions array rather than a targeted edit. Two consequences shaped the implementation: a concurrency group prevents two runs from clobbering each other, and the jq keeps negation patterns (e.g. !https://docs.crossplane.io/latest/concepts/composition/) at the end of pathsToMatch, since micromatch applies them positionally. Versioned negations are pruned along with their version.

The release issue template is updated accordingly: the two manual steps (edit config in the dashboard, trigger reindex) collapse into "run the Sync Docs Search workflow after publishing".

Access is gated by workflow_dispatch itself, which requires write access on the repo.

Tested on my fork Repo:

Update config
with dry-run:
<img width="626" height="705" alt="Screenshot 2026-08-26 at 09 51 49" src="https://github.com/user-attachments/assets/8e306779-0ac3-44c2-882c-601d1488621b" />

Trigger the Cralwer:
<img width="454" height="356" alt="Screenshot 2026-08-25 at 18 07 50" src="https://github.com/user-attachments/assets/ad8a9ce7-9777-4eb1-a27c-af3a8f654901" />

We need to add the following Secrets - if PR accepted ping me that we can set them up:
      ALGOLIA_CRAWLER_USER_ID
      ALGOLIA_CRAWLER_API_KEY
      ALGOLIA_CRAWLER_ID