### PR TITLE
fix(search): scope search on /latest pages to the latest version

### DIFF
--- a/themes/geekboot/layouts/partials/scripts.html
+++ b/themes/geekboot/layouts/partials/scripts.html
@@ -9,22 +9,28 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@docsearch/js@3"></script>
 <script>
-    {{ $cur_ver := "" }}
-    {{/* Only filter if we have a version parameter and it's not "0" (static pages) */}}
-    {{ if and .Page.Params.version (ne .Page.Params.version "0") }}
-        {{ if eq .Page.Params.version "master" }}
-            {{ $cur_ver = "0.0.0-master" }}
-        {{ else }}
-            {{ $cur_ver = .Page.Params.version }}
-        {{ end }}
-    {{ end }}
-
     {{/* Which track is this page on? Records are tagged "cli" or "core" by the
          crawler; everything that isn't the CLI track (core, knowledge base,
          contributing guide) searches the "core" records. */}}
     {{ $track := cond (eq (.Page.Params.track | default "core") "cli") "cli" "core" }}
     {{ $trackLatest := cond (eq $track "cli") .Site.Params.cliLatest .Site.Params.latest }}
     {{ $latestLink := cond (eq $track "cli") (printf "/cli/v%s/" .Site.Params.cliLatest) (printf "/v%s/" .Site.Params.latest) }}
+
+    {{ $cur_ver := "" }}
+    {{/* Every version folder is indexed, so always send a version facet.
+         Pages without a version param (the build-time /latest and /cli/latest
+         copies, the home page) fall back to the track's latest version.
+         Static pages (version "0": contribute guide, knowledge base) are
+         handled separately below so their own records stay searchable. */}}
+    {{ if and .Page.Params.version (ne .Page.Params.version "0") }}
+        {{ if eq .Page.Params.version "master" }}
+            {{ $cur_ver = "0.0.0-master" }}
+        {{ else }}
+            {{ $cur_ver = .Page.Params.version }}
+        {{ end }}
+    {{ else if not .Page.Params.version }}
+        {{ $cur_ver = $trackLatest }}
+    {{ end }}
 
     const docSearchInstance = docsearch({
         container: '#docSearch',
@@ -34,12 +40,12 @@
         placeholder: 'Search the docs',
         searchParameters: {
             attributesToRetrieve: ['hierarchy.lvl0', 'hierarchy.lvl1', 'hierarchy.lvl2', 'hierarchy.lvl3', 'hierarchy.lvl4', 'hierarchy.lvl5', 'hierarchy.lvl6', 'content', 'type', 'url', 'version'],
-            facetFilters: [['track:{{ $track }}']{{ if $cur_ver }}, ['version:{{ $cur_ver }}']{{ end }}]
+            facetFilters: [['track:{{ $track }}']{{ if $cur_ver }}, ['version:{{ $cur_ver }}']{{ else }}, ['version:0', 'version:{{ $trackLatest }}']{{ end }}]
         },
         transformItems(items) {
             // Add version warning banner and badges after DOM renders
             setTimeout(() => {
-                {{ if and $cur_ver (ne .Page.Params.version "master") (ne .Page.Params.version $trackLatest) }}
+                {{ if and $cur_ver .Page.Params.version (ne .Page.Params.version "master") (ne .Page.Params.version $trackLatest) }}
                 // Add warning banner for old version
                 const dropdown = document.querySelector('.DocSearch-Dropdown-Container');
                 if (dropdown && !dropdown.hasAttribute('data-version-banner-added')) {

--- a/themes/geekboot/layouts/partials/scripts.html
+++ b/themes/geekboot/layouts/partials/scripts.html
@@ -43,6 +43,19 @@
             facetFilters: [['track:{{ $track }}']{{ if $cur_ver }}, ['version:{{ $cur_ver }}']{{ else }}, ['version:0', 'version:{{ $trackLatest }}']{{ end }}]
         },
         transformItems(items) {
+            // Records store absolute production URLs; point hits at the host
+            // being viewed so deploy previews and local servers stay testable.
+            items.forEach(item => {
+                try {
+                    const itemUrl = new URL(item.url);
+                    if (itemUrl.origin !== window.location.origin) {
+                        item.url = window.location.origin + itemUrl.pathname + itemUrl.search + itemUrl.hash;
+                    }
+                } catch (e) {
+                    // Leave relative or malformed URLs untouched
+                }
+            });
+
             // Add version warning banner and badges after DOM renders
             setTimeout(() => {
                 {{ if and $cur_ver .Page.Params.version (ne .Page.Params.version "master") (ne .Page.Params.version $trackLatest) }}


### PR DESCRIPTION
<!--
Thanks for contributing to the docs! 

For information about local previews with Hugo read the contributing getting started guide:
https://docs.crossplane.io/contribute/contribute/

For information about Hugo's features like tabs and hint boxes read the styling features guide:
https://docs.crossplane.io/contribute/features/

For information on using Vale and testing locally read our Using Vale guide:
https://docs.crossplane.io/contribute/vale/

Need more help? Join the Crossplane Slack and ask in the #documentation channel.
https://slack.crossplane.io/
-->

### Problem

Searching from `/latest/` or `/cli/latest/` pages returns hits from every indexed version (v2.5, v2.4, v2.3, master, latest), showing the same page multiple times. This became visible on the CLI track, where nearly all content lives in a single command-reference page per version, but the core track has the same problem, it's just masked because Algolia's version-descending ranking fills the first screen of results with latest-version hits before the older duplicates appear.

The Netlify build strips the `version` front matter from the `latest` copies (`netlify_build.sh`), so `.Page.Params.version` is empty on all `/latest/`pages and the search template skipped the `version:` facet filter entirely, sending only `facetFilters: [["track:cli"]]`. That was correct when the crawler only indexed `/latest`, but is wrong now that every version folder is indexed with a `version` attribute.


Also guards the "Searching in an older version" banner so it doesn't fire on latest pages, where the effective search version is now set but the page has no version param.

Additionally, search results now stay on the host being viewed: Algolia records store absolute docs.crossplane.io URLs, which made search untestable on deploy previews since every hit navigated back to production. transformItems rewrites each hit's origin to window.location.origin (a no-op on production), so this PR's changes can be verified directly on its own preview.

