### PR TITLE
Document crossplane project run --no-default-mrap

### DIFF
--- a/content/cli/master/command-reference.md
+++ b/content/cli/master/command-reference.md
@@ -1354,6 +1354,15 @@ multiple projects side-by-side.
 You can use a Crossplane version other than the latest stable version by
 specifying the `--crossplane-version` flag.
 
+By default Crossplane installs a wildcard `ManagedResourceActivationPolicy`,
+which activates the CRDs for every managed resource its providers offer. Pass
+`--no-default-mrap` to skip it, so the control plane activates only the managed
+resources your project declares its own activation policies for. This matches
+what a production control plane looks like when it manages activation
+explicitly. Like `--cluster-admin`, this flag applies only when `run` creates
+the control plane. A control plane that already runs Crossplane keeps its
+original settings, so run `crossplane project stop` first to change them.
+
 You can provide resources to apply around the project install:
 
 - `--init-resources` applies one or more files *before* installing the
@@ -1381,6 +1390,13 @@ Pin the Crossplane version installed in the dev control plane:
 crossplane project run --crossplane-version=v2.2.1
 ```
 
+Run without the default wildcard activation policy, so only the project's own
+`ManagedResourceActivationPolicy` resources activate CRDs:
+
+```shell
+crossplane project run --no-default-mrap
+```
+
 Apply `imageconfig.yaml` before installing the Configuration, and
 `providerconfig.yaml` after:
 
@@ -1406,6 +1422,7 @@ crossplane project run [flags]
 |  | `--crossplane-version=STRING` | Version of Crossplane to install. |
 |  | `--registry-dir=STRING` | Directory for local registry images. |
 |  | `--cluster-admin` | Grant Crossplane the cluster-admin role. |
+|  | `--default-mrap` | Install the default wildcard ManagedResourceActivationPolicy in the dev control plane. |
 |  | `--timeout=5m` | Max wait for project readiness. |
 |  | `--init-resources=INIT-RESOURCES` | Resources to apply before installing. |
 |  | `--extra-resources=EXTRA-RESOURCES` | Resources to apply after installing. |


### PR DESCRIPTION
Documents the `--[no-]default-mrap` flag added to `crossplane project run` in crossplane/cli#302.

Crossplane's Helm chart defaults `provider.defaultActivations` to `["*"]`, so the local dev control plane always gets a wildcard `ManagedResourceActivationPolicy` activating every managed resource CRD its providers offer. `--no-default-mrap` skips it, so the control plane activates only what the project's own activation policies declare — closer to a production control plane that manages activation explicitly.

**Depends on crossplane/cli#302.** Please hold this until that merges.

### Notes for reviewers

- `content/cli/master/command-reference.md` is generated, so this was produced by running `crossplane generate-docs` against a build of the cli PR branch (with alpha features enabled, to match the existing content) rather than edited by hand. The diff is a pure 18-line addition: the help prose, an example, and the flag table row.
- The `This documentation is for the crossplane CLI ...` line is left at its existing value. A local `git describe` renders that version differently from the release build, and changing it here would be noise.
- Targets `master` rather than `v2.5`. `config.yaml` sets `cliLatest: "2.5"`, but the flag isn't in the released `v2.5.0` binary — `content/cli/master` currently reports `v2.6.0-rc.0`, which is where this lands. Happy to retarget if that's not the convention you want.
- `ManagedResourceActivationPolicy` and `MRAP` are already in `utils/vale/styles/Crossplane/crossplane-words.txt`, so vale should be clean. I wasn't able to run vale locally to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
